### PR TITLE
Fix uint16 overflow in terminal/interstitial telomere block counts

### DIFF
--- a/include/teloscope.h
+++ b/include/teloscope.h
@@ -102,11 +102,11 @@ struct GapInfo {
 struct TelomereBlock {
     uint64_t start = 0;
     uint32_t blockLen = 0; // End = start + blockLen
-    uint16_t blockCounts = 0;
-    uint16_t forwardCount = 0;
-    uint16_t reverseCount = 0;
-    uint16_t canonicalCount = 0;
-    uint16_t nonCanonicalCount = 0;
+    uint32_t blockCounts = 0;
+    uint32_t forwardCount = 0;
+    uint32_t reverseCount = 0;
+    uint32_t canonicalCount = 0;
+    uint32_t nonCanonicalCount = 0;
     uint32_t totalCovered = 0;
     uint32_t fwdCovered = 0;
     uint32_t canCovered = 0;
@@ -211,7 +211,7 @@ class Teloscope {
     }
 
 
-    static inline char computeBlockLabel(uint16_t forwardCount, uint16_t blockCounts) {
+    static inline char computeBlockLabel(uint32_t forwardCount, uint32_t blockCounts) {
         float forwardRatio = (forwardCount * 100.0f) / blockCounts;
         if (forwardRatio > 66.6f) return 'p';
         if (forwardRatio < 33.3f) return 'q';

--- a/src/teloscope.cpp
+++ b/src/teloscope.cpp
@@ -56,7 +56,7 @@ uint64_t Teloscope::getTerminalBlocks(
 
     bool inBlock = false;
     uint64_t blockStart = 0, blockEnd = 0, prevPosition = 0;
-    uint16_t blockCounts = 0, forwardCount = 0, canonicalCount = 0;
+    uint32_t blockCounts = 0, forwardCount = 0, canonicalCount = 0;
     uint32_t totalCovered = 0, fwdCovered = 0, canCovered = 0;
 
     auto startNewBlock = [&](const MatchInfo& m) {
@@ -192,7 +192,7 @@ void Teloscope::getInterstitialBlocks(
 
     bool inBlock = false;
     uint64_t blockStart = 0, blockEnd = 0, prevPosition = 0;
-    uint16_t blockCounts = 0, forwardCount = 0, canonicalCount = 0;
+    uint32_t blockCounts = 0, forwardCount = 0, canonicalCount = 0;
     uint32_t totalCovered = 0, fwdCovered = 0, canCovered = 0;
 
     auto startNewBlock = [&](const MatchInfo& m) {


### PR DESCRIPTION
## Problem
`TelomereBlock`'s five count fields — `blockCounts`, `forwardCount`, `reverseCount`, `canonicalCount`, `nonCanonicalCount` — are `uint16_t` (max 65535). A telomere block with more than 65,535 motif matches (canonical-dense blocks beyond ~393 kb) overflows, wrapping mod 65536 and corrupting the strand/canonical **count columns** of `*_terminal_telomeres.bed`. `getInterstitialBlocks()` uses the same scan accumulators, so interstitial blocks carry the same latent bug.

Block **coordinates and length** (`uint32_t`/`uint64_t`) are unaffected — only the count columns.

## Evidence (VGP 581-assembly run, v0.1.5)
Four terminal blocks overflowed. The clearest is a 970,129 bp terminal telomere:

| field | before (uint16) | after (uint32) |
|------:|----------------:|---------------:|
| rev    | 14327 | **145399** |
| can    | 33972 | **99508** |
| nonCan | 45891 | 45891 |

`14327 = 145399 mod 65536` and `33972 = 99508 mod 65536` — the exact wrap. The invariant `forwardCount + reverseCount == canonicalCount + nonCanonicalCount` failed on those rows before and holds after.

## Fix
Widen the five count fields, the two block-scan accumulators (`getTerminalBlocks`, `getInterstitialBlocks`), and `computeBlockLabel`'s parameters from `uint16_t` to `uint32_t`. Per-window counts are bounded by the window size and are left unchanged. The block **merge** logic was already correct — it re-aggregates every count across merged sub-blocks; only the field width was too narrow.

8 lines across `include/teloscope.h` and `src/teloscope.cpp`.
