### PR TITLE
Add Scaffold N50 and Contig N50 to the assembly summary report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ $(BINDIR):
 test-gaps: head
 	bash scripts/test_gaps_bed.sh
 
+test-n50: head
+	bash scripts/test_n50.sh
+
 test-bam: head
 	python3 scripts/test_bam_subset.py
 

--- a/include/teloscope.h
+++ b/include/teloscope.h
@@ -10,6 +10,7 @@
 #include <string>
 #include <string_view>
 #include <array>
+#include <algorithm>
 
 class Trie {
     struct TrieNode {
@@ -174,6 +175,8 @@ class Teloscope {
     uint32_t totalITS = 0;
     uint32_t totalCanMatches = 0;
     uint32_t totalGaps = 0;
+    uint64_t scaffoldN50 = 0;
+    uint64_t contigN50 = 0;
 
     // Telomere stats
     float teloMean = 0.0f;
@@ -216,6 +219,19 @@ class Teloscope {
         if (forwardRatio > 66.6f) return 'p';
         if (forwardRatio < 33.3f) return 'q';
         return 'b';
+    }
+
+    static inline uint64_t computeN50(std::vector<uint64_t>& lengths) {
+        if (lengths.empty()) return 0;
+        std::sort(lengths.begin(), lengths.end(), [](uint64_t a, uint64_t b) { return a > b; });
+        uint64_t total = 0;
+        for (uint64_t l : lengths) total += l;
+        uint64_t cum = 0;
+        for (uint64_t l : lengths) {
+            cum += l;
+            if (cum * 2 >= total) return l;
+        }
+        return lengths.back();
     }
 
     void computeSummaryCounts();

--- a/scripts/test_n50.sh
+++ b/scripts/test_n50.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Test Scaffold N50 / Contig N50 in the Assembly Summary Report.
+# Crafts a FASTA with known scaffold/contig structure and checks the reported N50s.
+#
+#   scaf1: 1000 bp + (50 N gap) + 600 bp   -> pathSize 1650, contigs {1000, 600}
+#   scaf2: 800 bp                          -> pathSize 800,  contig  {800}
+#
+#   scaffolds {1650, 800} (total 2450)  -> Scaffold N50 = 1650
+#   contigs   {1000, 800, 600} (total 2400) -> Contig N50 = 800
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TELO="$REPO_DIR/build/bin/teloscope"
+TMP_DIR="$REPO_DIR/testFiles/tmp_n50"
+
+red()   { printf "\033[0;31m%s\033[0m" "$1"; }
+green() { printf "\033[0;32m%s\033[0m" "$1"; }
+
+if [ ! -x "$TELO" ]; then
+    echo "Error: teloscope binary not found at $TELO (run 'make' first)"; exit 1
+fi
+
+rm -rf "$TMP_DIR"; mkdir -p "$TMP_DIR"
+FA="$TMP_DIR/n50_basic.fa"
+{
+    echo ">scaf1"
+    awk 'BEGIN{for(i=0;i<1000;i++)printf "A"; for(i=0;i<50;i++)printf "N"; for(i=0;i<600;i++)printf "A"; print ""}'
+    echo ">scaf2"
+    awk 'BEGIN{for(i=0;i<800;i++)printf "A"; print ""}'
+} > "$FA"
+
+OUT=$("$TELO" -f "$FA" -o "$TMP_DIR/out" 2>/dev/null) || true
+
+scaf=$(printf '%s\n' "$OUT" | awk -F'\t' '/^Scaffold N50:/{print $2; exit}')
+ctg=$(printf '%s\n' "$OUT"  | awk -F'\t' '/^Contig N50:/{print $2; exit}')
+
+EXP_SCAF=1650
+EXP_CTG=800
+fail=0
+
+if [ "${scaf:-}" = "$EXP_SCAF" ]; then
+    echo "  $(green PASS) Scaffold N50 = $scaf"
+else
+    echo "  $(red FAIL) Scaffold N50 = '${scaf:-<missing>}' (expected $EXP_SCAF)"; fail=1
+fi
+if [ "${ctg:-}" = "$EXP_CTG" ]; then
+    echo "  $(green PASS) Contig N50 = $ctg"
+else
+    echo "  $(red FAIL) Contig N50 = '${ctg:-<missing>}' (expected $EXP_CTG)"; fail=1
+fi
+
+rm -rf "$TMP_DIR"
+[ "$fail" -eq 0 ] && { echo "test_n50: all passed"; exit 0; } || { echo "test_n50: FAILED"; exit 1; }

--- a/src/teloscope.cpp
+++ b/src/teloscope.cpp
@@ -957,6 +957,10 @@ void Teloscope::handleBEDFile() {
 
 
 void Teloscope::computeSummaryCounts() {
+    std::vector<uint64_t> scaffoldLens;
+    std::vector<uint64_t> contigLens;
+    scaffoldLens.reserve(allPathData.size());
+
     for (const auto& pathData : allPathData) {
         switch (pathData.scaffoldType) {
             case ScaffoldType::T2T:                   totalT2T++; break;
@@ -970,7 +974,22 @@ void Teloscope::computeSummaryCounts() {
             case ScaffoldType::DISCORDANT:            totalDiscordant++; break;
             case ScaffoldType::GAPPED_DISCORDANT:     totalGappedDiscordant++; break;
         }
+
+        // contig lengths = runs between gaps
+        scaffoldLens.push_back(pathData.pathSize);
+        std::vector<GapInfo> gaps = pathData.gapInfos;
+        std::sort(gaps.begin(), gaps.end(),
+                  [](const GapInfo& a, const GapInfo& b) { return a.start < b.start; });
+        uint64_t prevEnd = 0;
+        for (const auto& g : gaps) {
+            if (g.start > prevEnd) contigLens.push_back(g.start - prevEnd);
+            prevEnd = g.start + g.length;
+        }
+        if (pathData.pathSize > prevEnd) contigLens.push_back(pathData.pathSize - prevEnd);
     }
+
+    scaffoldN50 = computeN50(scaffoldLens);
+    contigN50 = computeN50(contigLens);
 }
 
 
@@ -988,6 +1007,8 @@ void Teloscope::printSummary(std::ofstream& reportFile) {
     out("\n+++ Assembly Summary Report +++\n");
     out("Total paths:\t", totalPaths, "\n");
     out("Total gaps:\t", totalGaps, "\n");
+    out("Scaffold N50:\t", scaffoldN50, "\n");
+    out("Contig N50:\t", contigN50, "\n");
     out("Total telomeres:\t", totalTelomeres, "\n");
 
     if (!userInput.ultraFastMode) {

--- a/validateFiles/bTaeGut7_chr33_mat.fa.gz.8207638190238294933.tst
+++ b/validateFiles/bTaeGut7_chr33_mat.fa.gz.8207638190238294933.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	4246341
+Contig N50:	4246341
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/bTaeGut7_chr33_pat.fa.gz.12556678887398187316.tst
+++ b/validateFiles/bTaeGut7_chr33_pat.fa.gz.12556678887398187316.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	4788276
+Contig N50:	4788276
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/balanced.fa.40154309800253662.tst
+++ b/validateFiles/balanced.fa.40154309800253662.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3600
+Contig N50:	3600
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/balanced.fa.5826546014912286609.tst
+++ b/validateFiles/balanced.fa.5826546014912286609.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3600
+Contig N50:	3600
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	199

--- a/validateFiles/boundary_cross.fa.13020474306905345955.tst
+++ b/validateFiles/boundary_cross.fa.13020474306905345955.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	2400
+Contig N50:	2400
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_cross.fa.3735611299792264663.tst
+++ b/validateFiles/boundary_cross.fa.3735611299792264663.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	2400
+Contig N50:	2400
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	398

--- a/validateFiles/boundary_cross.fa.6531405748876533371.tst
+++ b/validateFiles/boundary_cross.fa.6531405748876533371.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	2400
+Contig N50:	2400
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_extend_its.fa.17360651251356497434.tst
+++ b/validateFiles/boundary_extend_its.fa.17360651251356497434.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	4500
+Contig N50:	4500
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_extend_its.fa.6234164114180216121.tst
+++ b/validateFiles/boundary_extend_its.fa.6234164114180216121.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	4500
+Contig N50:	4500
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_extend_its.fa.8506167252562348633.tst
+++ b/validateFiles/boundary_extend_its.fa.8506167252562348633.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	4500
+Contig N50:	4500
 Total telomeres:	2
 Total ITS blocks:	1
 Total canonical matches:	249

--- a/validateFiles/boundary_fail_filter.fa.10542290532062691905.tst
+++ b/validateFiles/boundary_fail_filter.fa.10542290532062691905.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3120
+Contig N50:	3120
 Total telomeres:	0
 Total ITS blocks:	1
 Total canonical matches:	20

--- a/validateFiles/boundary_fail_filter.fa.3031730917511083852.tst
+++ b/validateFiles/boundary_fail_filter.fa.3031730917511083852.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3120
+Contig N50:	3120
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_fail_filter.fa.3973564589040788049.tst
+++ b/validateFiles/boundary_fail_filter.fa.3973564589040788049.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3120
+Contig N50:	3120
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_its_at_edge.fa.11759099044405052363.tst
+++ b/validateFiles/boundary_its_at_edge.fa.11759099044405052363.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3460
+Contig N50:	3460
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_its_at_edge.fa.15482798331432621807.tst
+++ b/validateFiles/boundary_its_at_edge.fa.15482798331432621807.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3460
+Contig N50:	3460
 Total telomeres:	2
 Total ITS blocks:	1
 Total canonical matches:	209

--- a/validateFiles/boundary_its_at_edge.fa.6903283384390650609.tst
+++ b/validateFiles/boundary_its_at_edge.fa.6903283384390650609.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3460
+Contig N50:	3460
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_multiple_p.fa.1667166354044658508.tst
+++ b/validateFiles/boundary_multiple_p.fa.1667166354044658508.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3500
+Contig N50:	3500
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_multiple_p.fa.18043495993369345633.tst
+++ b/validateFiles/boundary_multiple_p.fa.18043495993369345633.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3500
+Contig N50:	3500
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	199

--- a/validateFiles/boundary_multiple_p.fa.4751366234288938161.tst
+++ b/validateFiles/boundary_multiple_p.fa.4751366234288938161.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3500
+Contig N50:	3500
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_no_terminal.fa.1137483968764364371.tst
+++ b/validateFiles/boundary_no_terminal.fa.1137483968764364371.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	7200
+Contig N50:	7200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_no_terminal.fa.4800093562341469789.tst
+++ b/validateFiles/boundary_no_terminal.fa.4800093562341469789.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	7200
+Contig N50:	7200
 Total telomeres:	0
 Total ITS blocks:	2
 Total canonical matches:	199

--- a/validateFiles/boundary_no_terminal.fa.8978991277979939893.tst
+++ b/validateFiles/boundary_no_terminal.fa.8978991277979939893.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	7200
+Contig N50:	7200
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_zone_shift.fa.13723892003150963217.tst
+++ b/validateFiles/boundary_zone_shift.fa.13723892003150963217.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	4200
+Contig N50:	4200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_zone_shift.fa.17484482852492555982.tst
+++ b/validateFiles/boundary_zone_shift.fa.17484482852492555982.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	4200
+Contig N50:	4200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_zone_shift.fa.17799911741869550234.tst
+++ b/validateFiles/boundary_zone_shift.fa.17799911741869550234.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	4200
+Contig N50:	4200
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/boundary_zone_shift.fa.381825507404938648.tst
+++ b/validateFiles/boundary_zone_shift.fa.381825507404938648.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	4200
+Contig N50:	4200
 Total telomeres:	0
 Total ITS blocks:	2
 Total canonical matches:	199

--- a/validateFiles/density_edge.fa.11502240591095362965.tst
+++ b/validateFiles/density_edge.fa.11502240591095362965.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3800
+Contig N50:	3800
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/density_edge.fa.15291423402811723758.tst
+++ b/validateFiles/density_edge.fa.15291423402811723758.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3800
+Contig N50:	3800
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/density_edge.fa.16848693945977157689.tst
+++ b/validateFiles/density_edge.fa.16848693945977157689.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3800
+Contig N50:	3800
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/density_edge.fa.18054528507961120224.tst
+++ b/validateFiles/density_edge.fa.18054528507961120224.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3800
+Contig N50:	3800
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/density_edge.fa.18205122285884255215.tst
+++ b/validateFiles/density_edge.fa.18205122285884255215.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3800
+Contig N50:	3800
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/density_edge.fa.18205132181488909114.tst
+++ b/validateFiles/density_edge.fa.18205132181488909114.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3800
+Contig N50:	3800
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/density_edge.fa.9397584258762442869.tst
+++ b/validateFiles/density_edge.fa.9397584258762442869.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3800
+Contig N50:	3800
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/discordant.fa.11246817303817945175.tst
+++ b/validateFiles/discordant.fa.11246817303817945175.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3400
+Contig N50:	3400
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/discordant.fa.17076018569760988620.tst
+++ b/validateFiles/discordant.fa.17076018569760988620.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3400
+Contig N50:	3400
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/discordant.fa.6693548016568360343.tst
+++ b/validateFiles/discordant.fa.6693548016568360343.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3400
+Contig N50:	3400
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/discordant_pp.fa.12776411765711091049.tst
+++ b/validateFiles/discordant_pp.fa.12776411765711091049.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5000
+Contig N50:	5000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/discordant_pp.fa.1691888444982929862.tst
+++ b/validateFiles/discordant_pp.fa.1691888444982929862.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5000
+Contig N50:	5000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/discordant_pp.fa.1754542856454471898.tst
+++ b/validateFiles/discordant_pp.fa.1754542856454471898.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5000
+Contig N50:	5000
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	183

--- a/validateFiles/edit_test.fa.11447876324003910593.tst
+++ b/validateFiles/edit_test.fa.11447876324003910593.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/edit_test.fa.220735128471403188.tst
+++ b/validateFiles/edit_test.fa.220735128471403188.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/edit_test.fa.220738427006287821.tst
+++ b/validateFiles/edit_test.fa.220738427006287821.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/edit_test.fa.610030987222177946.tst
+++ b/validateFiles/edit_test.fa.610030987222177946.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/extra_invalid_p.fa.13295336059650318682.tst
+++ b/validateFiles/extra_invalid_p.fa.13295336059650318682.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5000
+Contig N50:	5000
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	183

--- a/validateFiles/extra_invalid_p.fa.3647993463702844137.tst
+++ b/validateFiles/extra_invalid_p.fa.3647993463702844137.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5000
+Contig N50:	5000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/extra_invalid_p.fa.6659662568848107073.tst
+++ b/validateFiles/extra_invalid_p.fa.6659662568848107073.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5000
+Contig N50:	5000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_discordant.fa.5739140088010086199.tst
+++ b/validateFiles/gapped_discordant.fa.5739140088010086199.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	3200
+Contig N50:	2000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_discordant_q.fa.10975518228652460194.tst
+++ b/validateFiles/gapped_discordant_q.fa.10975518228652460194.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	5000
+Contig N50:	2600
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	100

--- a/validateFiles/gapped_discordant_q.fa.15712996612775304625.tst
+++ b/validateFiles/gapped_discordant_q.fa.15712996612775304625.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	5000
+Contig N50:	2600
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_discordant_q.fa.5163774608685122727.tst
+++ b/validateFiles/gapped_discordant_q.fa.5163774608685122727.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	5000
+Contig N50:	2600
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_incomplete.fa.9330880998069560118.tst
+++ b/validateFiles/gapped_incomplete.fa.9330880998069560118.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	3700
+Contig N50:	2000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_incomplete_q.fa.10160883203849856346.tst
+++ b/validateFiles/gapped_incomplete_q.fa.10160883203849856346.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	5000
+Contig N50:	2900
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	100

--- a/validateFiles/gapped_incomplete_q.fa.473402016514536682.tst
+++ b/validateFiles/gapped_incomplete_q.fa.473402016514536682.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	5000
+Contig N50:	2900
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_incomplete_q.fa.8157320685243948777.tst
+++ b/validateFiles/gapped_incomplete_q.fa.8157320685243948777.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	5000
+Contig N50:	2900
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_misassembly.fa.12185823610694596883.tst
+++ b/validateFiles/gapped_misassembly.fa.12185823610694596883.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	6800
+Contig N50:	3700
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_misassembly_qq.fa.11518523177856386838.tst
+++ b/validateFiles/gapped_misassembly_qq.fa.11518523177856386838.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	5000
+Contig N50:	4400
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	184

--- a/validateFiles/gapped_misassembly_qq.fa.16866526250789306140.tst
+++ b/validateFiles/gapped_misassembly_qq.fa.16866526250789306140.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	5000
+Contig N50:	4400
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_misassembly_qq.fa.3679090955786281725.tst
+++ b/validateFiles/gapped_misassembly_qq.fa.3679090955786281725.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	5000
+Contig N50:	4400
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_none.fa.284056275220561908.tst
+++ b/validateFiles/gapped_none.fa.284056275220561908.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	3100
+Contig N50:	2000
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_t2t.fa.11306676200400447792.tst
+++ b/validateFiles/gapped_t2t.fa.11306676200400447792.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	3100
+Contig N50:	1500
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	199

--- a/validateFiles/gapped_t2t.fa.13585412352192038024.tst
+++ b/validateFiles/gapped_t2t.fa.13585412352192038024.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	3100
+Contig N50:	1500
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_t2t.fa.3564330876054826666.tst
+++ b/validateFiles/gapped_t2t.fa.3564330876054826666.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	3100
+Contig N50:	1500
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	199

--- a/validateFiles/gapped_t2t.fa.8220347404831251449.tst
+++ b/validateFiles/gapped_t2t.fa.8220347404831251449.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	3100
+Contig N50:	1500
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/gapped_t2t.fa.9885967296614119362.tst
+++ b/validateFiles/gapped_t2t.fa.9885967296614119362.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	1
+Scaffold N50:	3100
+Contig N50:	1500
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/incomplete_p.fa.13049642363909183847.tst
+++ b/validateFiles/incomplete_p.fa.13049642363909183847.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/incomplete_p.fa.2149153878052316395.tst
+++ b/validateFiles/incomplete_p.fa.2149153878052316395.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/incomplete_p.fa.7535770476637010389.tst
+++ b/validateFiles/incomplete_p.fa.7535770476637010389.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/incomplete_q.fa.404477746014459402.tst
+++ b/validateFiles/incomplete_q.fa.404477746014459402.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/incomplete_q.fa.7185846585312997661.tst
+++ b/validateFiles/incomplete_q.fa.7185846585312997661.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	100

--- a/validateFiles/its.fa.15389618344773051174.tst
+++ b/validateFiles/its.fa.15389618344773051174.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	7800
+Contig N50:	7800
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/its.fa.3319195622443024993.tst
+++ b/validateFiles/its.fa.3319195622443024993.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	7800
+Contig N50:	7800
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	299

--- a/validateFiles/its.fa.5508151194798867448.tst
+++ b/validateFiles/its.fa.5508151194798867448.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	7800
+Contig N50:	7800
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/its.fa.6981663779685695639.tst
+++ b/validateFiles/its.fa.6981663779685695639.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	7800
+Contig N50:	7800
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	299

--- a/validateFiles/mirror_both_end.fa.13454224414378762766.tst
+++ b/validateFiles/mirror_both_end.fa.13454224414378762766.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	199

--- a/validateFiles/mirror_both_end.fa.18162458361112469429.tst
+++ b/validateFiles/mirror_both_end.fa.18162458361112469429.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_both_end.fa.3448531299711508025.tst
+++ b/validateFiles/mirror_both_end.fa.3448531299711508025.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_both_start.fa.13475978796880262586.tst
+++ b/validateFiles/mirror_both_start.fa.13475978796880262586.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	199

--- a/validateFiles/mirror_both_start.fa.18415584902962254004.tst
+++ b/validateFiles/mirror_both_start.fa.18415584902962254004.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_both_start.fa.2118943370675150985.tst
+++ b/validateFiles/mirror_both_start.fa.2118943370675150985.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_extend.fa.17701753921683907024.tst
+++ b/validateFiles/mirror_extend.fa.17701753921683907024.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_extend.fa.2014389609630938586.tst
+++ b/validateFiles/mirror_extend.fa.2014389609630938586.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	100

--- a/validateFiles/mirror_extend.fa.6461553273606663273.tst
+++ b/validateFiles/mirror_extend.fa.6461553273606663273.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_fwd_end_long.fa.13574083730069612003.tst
+++ b/validateFiles/mirror_fwd_end_long.fa.13574083730069612003.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5200
+Contig N50:	5200
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_fwd_end_long.fa.9439456304929687150.tst
+++ b/validateFiles/mirror_fwd_end_long.fa.9439456304929687150.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5200
+Contig N50:	5200
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_inverted_long.fa.1074704251209791115.tst
+++ b/validateFiles/mirror_inverted_long.fa.1074704251209791115.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5200
+Contig N50:	5200
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_inverted_long.fa.10923823821893146314.tst
+++ b/validateFiles/mirror_inverted_long.fa.10923823821893146314.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5200
+Contig N50:	5200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_inverted_long.fa.3499006673264178540.tst
+++ b/validateFiles/mirror_inverted_long.fa.3499006673264178540.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5200
+Contig N50:	5200
 Total telomeres:	0
 Total ITS blocks:	2
 Total canonical matches:	199

--- a/validateFiles/mirror_inverted_short.fa.14937720680823646380.tst
+++ b/validateFiles/mirror_inverted_short.fa.14937720680823646380.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_inverted_short.fa.2663948705559532641.tst
+++ b/validateFiles/mirror_inverted_short.fa.2663948705559532641.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_inverted_short.fa.880866077318884242.tst
+++ b/validateFiles/mirror_inverted_short.fa.880866077318884242.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	199

--- a/validateFiles/mirror_merge.fa.14661859976539855934.tst
+++ b/validateFiles/mirror_merge.fa.14661859976539855934.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	2700
+Contig N50:	2700
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_merge.fa.801288088898993465.tst
+++ b/validateFiles/mirror_merge.fa.801288088898993465.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	2700
+Contig N50:	2700
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_merge.fa.9456585347008871658.tst
+++ b/validateFiles/mirror_merge.fa.9456585347008871658.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	2700
+Contig N50:	2700
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	100

--- a/validateFiles/mirror_no_merge.fa.2296521019379221497.tst
+++ b/validateFiles/mirror_no_merge.fa.2296521019379221497.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	2780
+Contig N50:	2780
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_no_merge.fa.6732681955904529852.tst
+++ b/validateFiles/mirror_no_merge.fa.6732681955904529852.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	2780
+Contig N50:	2780
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_rev_start.fa.11969824359334098420.tst
+++ b/validateFiles/mirror_rev_start.fa.11969824359334098420.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_rev_start.fa.15863878593977287254.tst
+++ b/validateFiles/mirror_rev_start.fa.15863878593977287254.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	100

--- a/validateFiles/mirror_rev_start.fa.18054712643729730621.tst
+++ b/validateFiles/mirror_rev_start.fa.18054712643729730621.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_rev_start_long.fa.14214951430868661743.tst
+++ b/validateFiles/mirror_rev_start_long.fa.14214951430868661743.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5200
+Contig N50:	5200
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/mirror_rev_start_long.fa.9414978925266285797.tst
+++ b/validateFiles/mirror_rev_start_long.fa.9414978925266285797.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	5200
+Contig N50:	5200
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/misassembly.fa.2399223831834658547.tst
+++ b/validateFiles/misassembly.fa.2399223831834658547.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	6700
+Contig N50:	6700
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/misassembly.fa.6682312758429925465.tst
+++ b/validateFiles/misassembly.fa.6682312758429925465.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	6700
+Contig N50:	6700
 Total telomeres:	1
 Total ITS blocks:	0
 Total canonical matches:	200

--- a/validateFiles/misassembly_qq.fa.7627058265365559612.tst
+++ b/validateFiles/misassembly_qq.fa.7627058265365559612.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	7200
+Contig N50:	7200
 Total telomeres:	1
 
 +++ Telomere Statistics +++

--- a/validateFiles/multi.fa.11340116012829529476.tst
+++ b/validateFiles/multi.fa.11340116012829529476.tst
@@ -10,6 +10,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	3
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	3
 
 +++ Telomere Statistics +++

--- a/validateFiles/multi.fa.11817945195937582221.tst
+++ b/validateFiles/multi.fa.11817945195937582221.tst
@@ -10,6 +10,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	3
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	3
 
 +++ Telomere Statistics +++

--- a/validateFiles/multi.fa.14460913742427464365.tst
+++ b/validateFiles/multi.fa.14460913742427464365.tst
@@ -10,6 +10,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	3
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/multi.fa.1507974511893542949.tst
+++ b/validateFiles/multi.fa.1507974511893542949.tst
@@ -10,6 +10,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	3
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	3
 Total ITS blocks:	0
 Total canonical matches:	299

--- a/validateFiles/multi.fa.1650471217673912289.tst
+++ b/validateFiles/multi.fa.1650471217673912289.tst
@@ -10,6 +10,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	3
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	3
 
 +++ Telomere Statistics +++

--- a/validateFiles/multi.fa.3865434927606782801.tst
+++ b/validateFiles/multi.fa.3865434927606782801.tst
@@ -10,6 +10,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	3
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	3
 Total ITS blocks:	0
 Total canonical matches:	299

--- a/validateFiles/multi.fa.4039192076584536230.tst
+++ b/validateFiles/multi.fa.4039192076584536230.tst
@@ -10,6 +10,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	3
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	3
 Total ITS blocks:	0
 Total canonical matches:	299

--- a/validateFiles/multi.fa.6407311943605380284.tst
+++ b/validateFiles/multi.fa.6407311943605380284.tst
@@ -10,6 +10,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	3
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	3
 
 +++ Telomere Statistics +++

--- a/validateFiles/multi_gap_t2t.fa.13178773043066003110.tst
+++ b/validateFiles/multi_gap_t2t.fa.13178773043066003110.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	2
+Scaffold N50:	2500
+Contig N50:	1000
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	200

--- a/validateFiles/multi_gap_t2t.fa.15761604338057371277.tst
+++ b/validateFiles/multi_gap_t2t.fa.15761604338057371277.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	2
+Scaffold N50:	2500
+Contig N50:	1000
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/multi_gap_t2t.fa.5837101565488420220.tst
+++ b/validateFiles/multi_gap_t2t.fa.5837101565488420220.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	2
+Scaffold N50:	2500
+Contig N50:	1000
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	200

--- a/validateFiles/multi_gap_t2t.fa.8925899339541144219.tst
+++ b/validateFiles/multi_gap_t2t.fa.8925899339541144219.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	2
+Scaffold N50:	2500
+Contig N50:	1000
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/no_telo.fa.2837662462219961694.tst
+++ b/validateFiles/no_telo.fa.2837662462219961694.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/no_telo.fa.7723326043873406837.tst
+++ b/validateFiles/no_telo.fa.7723326043873406837.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3000
+Contig N50:	3000
 Total telomeres:	0
 Total ITS blocks:	0
 Total canonical matches:	0

--- a/validateFiles/plant.fa.12048815928199878009.tst
+++ b/validateFiles/plant.fa.12048815928199878009.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3204
+Contig N50:	3204
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/plant.fa.12580276364134102776.tst
+++ b/validateFiles/plant.fa.12580276364134102776.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3204
+Contig N50:	3204
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/plant.fa.13208736407219036227.tst
+++ b/validateFiles/plant.fa.13208736407219036227.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3204
+Contig N50:	3204
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/plant.fa.9744200052282298469.tst
+++ b/validateFiles/plant.fa.9744200052282298469.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3204
+Contig N50:	3204
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/short_contig.fa.15916145240921373996.tst
+++ b/validateFiles/short_contig.fa.15916145240921373996.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	100
+Contig N50:	100
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/short_contig.fa.5476401624148323381.tst
+++ b/validateFiles/short_contig.fa.5476401624148323381.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	100
+Contig N50:	100
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.10252446504263324249.tst
+++ b/validateFiles/t2t.fa.10252446504263324249.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	199

--- a/validateFiles/t2t.fa.10444993675934806744.tst
+++ b/validateFiles/t2t.fa.10444993675934806744.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.10533879463983422414.tst
+++ b/validateFiles/t2t.fa.10533879463983422414.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	196

--- a/validateFiles/t2t.fa.1063133428552632776.tst
+++ b/validateFiles/t2t.fa.1063133428552632776.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.10818560813968716400.tst
+++ b/validateFiles/t2t.fa.10818560813968716400.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	199

--- a/validateFiles/t2t.fa.11528485575328238826.tst
+++ b/validateFiles/t2t.fa.11528485575328238826.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	199

--- a/validateFiles/t2t.fa.11555839502624859929.tst
+++ b/validateFiles/t2t.fa.11555839502624859929.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.12307214653694242105.tst
+++ b/validateFiles/t2t.fa.12307214653694242105.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.13137366937651507234.tst
+++ b/validateFiles/t2t.fa.13137366937651507234.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.13426259501337498168.tst
+++ b/validateFiles/t2t.fa.13426259501337498168.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular	its	canonical	windows
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 Total ITS blocks:	0
 Total canonical matches:	199

--- a/validateFiles/t2t.fa.14366911921754390127.tst
+++ b/validateFiles/t2t.fa.14366911921754390127.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.14627900428347240552.tst
+++ b/validateFiles/t2t.fa.14627900428347240552.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.14748217205310938168.tst
+++ b/validateFiles/t2t.fa.14748217205310938168.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.16902264165075168028.tst
+++ b/validateFiles/t2t.fa.16902264165075168028.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.18155110826882189740.tst
+++ b/validateFiles/t2t.fa.18155110826882189740.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.4723209895525356441.tst
+++ b/validateFiles/t2t.fa.4723209895525356441.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.4723214293571869285.tst
+++ b/validateFiles/t2t.fa.4723214293571869285.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.6534487077242095808.tst
+++ b/validateFiles/t2t.fa.6534487077242095808.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.6534491475288608652.tst
+++ b/validateFiles/t2t.fa.6534491475288608652.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.6943945302206683552.tst
+++ b/validateFiles/t2t.fa.6943945302206683552.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.7572888764822735024.tst
+++ b/validateFiles/t2t.fa.7572888764822735024.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	0
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.8424852773259048552.tst
+++ b/validateFiles/t2t.fa.8424852773259048552.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++

--- a/validateFiles/t2t.fa.8628717505568100642.tst
+++ b/validateFiles/t2t.fa.8628717505568100642.tst
@@ -8,6 +8,8 @@ pos	header	telomeres	labels	gaps	type	granular
 +++ Assembly Summary Report +++
 Total paths:	1
 Total gaps:	0
+Scaffold N50:	3200
+Contig N50:	3200
 Total telomeres:	2
 
 +++ Telomere Statistics +++


### PR DESCRIPTION
## Summary
Adds **Scaffold N50** and **Contig N50** to the per-assembly summary report (`*_report.tsv` / stdout), next to the existing `Total gaps` line. This completes the structural-QC fields Teloscope already emits (gaps, scaffold length) so downstream analyses can read N50 straight from the freeze instead of a separate gfastats pass.

## Details
- `computeSummaryCounts()` accumulates per-path **scaffold** lengths (`pathData.pathSize`) and **contig** lengths (path runs split at `gapInfos`).
- New `computeN50()` helper returns the standard N50 (sort desc, length crossing 50% of total).
- No `gfalibs` submodule change.

## Report
```
+++ Assembly Summary Report +++
Total paths:    1
Total gaps:     2
Scaffold N50:   2500
Contig N50:     1000
Total telomeres:        2
```

## Tests
- New `scripts/test_n50.sh` (+ `make test-n50`): two-scaffold, one-gap assembly → asserts Scaffold N50 = 1650, Contig N50 = 800.
- `make test-gaps` regression: 12/12 pass.