### PR TITLE
CI: publish release only after all assets are attached

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -15,12 +15,17 @@ jobs:
       uses: actions/checkout@v6
       with:
         submodules: recursive
+    # Create as a draft so the release is invisible until every asset is
+    # attached. Bioconda's autobump bot downloads
+    # teloscope.v<version>-with_submodules.zip to compute the recipe sha256; if
+    # the release published before that (slow) upload finished, the bot could
+    # 404 and land a bad hash. publish_release flips draft->false at the end.
     - name: Create Release
       uses: softprops/action-gh-release@v2
       with:
         name: teloscope ${{ github.ref_name }}
         generate_release_notes: true
-        draft: false
+        draft: true
         prerelease: false
 
   add_resources:
@@ -81,3 +86,17 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ steps.package.outputs.asset }}
+
+  # Publish only after all assets are uploaded, so the release (and its
+  # download URLs) become visible to the Bioconda autobump bot atomically.
+  publish_release:
+    needs: [add_resources, add_submodules]
+    name: Publish Release
+    permissions: write-all
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish
+        uses: softprops/action-gh-release@v2
+        with:
+          name: teloscope ${{ github.ref_name }}
+          draft: false


### PR DESCRIPTION
## Problem

`create_release.yml` publishes the GitHub release immediately (`draft: false`), then the separate, slower `add_submodules` job builds and uploads `teloscope.v<version>-with_submodules.zip`.

Bioconda's autobump bot polls for new releases and downloads that asset to compute the recipe `sha256`. If it polls during the window before the submodule-zip upload finishes, the asset 404s and the bump lands with a bad/missing hash — which is why several version bumps have needed the sha256 corrected by hand.

## Fix

Draft-then-publish:

1. `create_release` now creates the release as a **draft** (`draft: true`).
2. A new `publish_release` job (`needs: [add_resources, add_submodules]`) flips it to published (`draft: false`) only after every asset is attached.

The upload jobs are unchanged: they find the draft release by tag and append files to it, and — because they don't pass a `draft:` input — leave the draft status untouched. So the release (and its download URLs) becomes visible to the autobump bot atomically, with `-with_submodules.zip` already present.

The asset name pattern `teloscope.v<version>-with_submodules.zip` is unchanged (the Bioconda recipe URL depends on it).
