### PR TITLE
Add assembly record inclusion and exclusion filters

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,6 +35,9 @@ jobs:
     - name: Validate BAM subset
       run: python3 scripts/test_bam_subset.py
 
+    - name: Validate assembly record filters
+      run: python3 scripts/test_sequence_filters.py
+
   bam-coverage:
     name: BAM 100% executable-line coverage
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ test-n50: head
 test-bam: head
 	python3 scripts/test_bam_subset.py
 
+.PHONY: test-filters
+test-filters: head
+	TELOSCOPE="$(BUILD)/$(TARGET)" python3 scripts/test_sequence_filters.py
+
 .PHONY: test-bam-hardening test-bam-coverage test-bam-sanitize
 test-bam-hardening: head
 	TELOSCOPE="$(BUILD)/$(TARGET)" BAM_MUTATION_CASES="$${BAM_MUTATION_CASES:-512}" python3 scripts/test_bam_subset.py

--- a/README.md
+++ b/README.md
@@ -62,8 +62,6 @@ For `--plot-report`, install Python 3 with `matplotlib`, `numpy`, and `pandas`.
 | Scan a vertebrate assembly with the default motif | `teloscope asm.fa` |
 | Read compressed FASTA directly | `teloscope asm.fa.gz` |
 | Write all optional FASTA outputs | `teloscope asm.fa -o results/ -r -g -e -m -i --plot-report` |
-| Keep one inspected submitter naming family | `teloscope asm.fa --include-prefix hap1_chr -o results/` |
-| Keep exact sequence IDs from a BED/list file (safest for database assemblies) | `teloscope asm.fa --include-bed chromosomes.ids -o results/` |
 | Switch to a plant canonical repeat | `teloscope asm.fa -c CCCTAAA` |
 | Search explicit motif variants | `teloscope asm.fa -c TTAGGG -p TTAGGG,TCAGGG,TGAGGG,TTGGGG` |
 | Annotate a graph for BandageNG | `teloscope asm.gfa -o results/` |
@@ -85,46 +83,20 @@ Notes:
 
 ## Filter assembly records
 
-Record filtering is off by default, so existing FASTA and GFA behavior is unchanged. When filtering is active, the selection domain is every FASTA record, every supported GFA1 `P` path, or every segment in a pathless GFA1 graph.
+Filtering is off by default. All four flags can be repeated, and matching is case-sensitive.
 
-| Flag | Value | Default | Effect |
-| --- | --- | --- | --- |
-| `--include-bed FILE` | BED or one-ID-per-line file | not set | keep records whose complete primary ID occurs in column 1 |
-| `--exclude-bed FILE` | BED or one-ID-per-line file | not set | remove records whose complete primary ID occurs in column 1 |
-| `--include-prefix LIST` | comma-separated literal prefixes | not set | keep records whose primary ID starts with any listed prefix |
-| `--exclude-prefix LIST` | comma-separated literal prefixes | not set | remove records whose primary ID starts with any listed prefix |
+| Flag | Effect | Default |
+| --- | --- | --- |
+| `--include-bed FILE` | keep IDs listed in column 1 | unset |
+| `--exclude-bed FILE` | remove IDs listed in column 1 | unset |
+| `--include-prefix LIST` | keep IDs with any comma-separated prefix | unset |
+| `--exclude-prefix LIST` | remove IDs with any comma-separated prefix | unset |
 
-The BED pair uses the familiar gfastats flag names for an auditable exact-ID workflow, but Teloscope deliberately treats column 1 as a whole-record selector. This avoids coordinate edits that could change terminal context. The options are long-only because Teloscope already uses `-i` for ITS output and `-e` for entropy output. The prefix pair handles a known accession family without forcing users to generate a list or enabling error-prone regex syntax.
+Includes form a union and exclusions run last. Without an include flag, all records start selected. Prefixes are literal strings. Selector files accept one ID per line or BED3+ rows; column 1 selects a whole record, and BED coordinates never crop sequences.
 
-All four flags can be repeated. If no include flag is set, every input record starts selected. If one or more include flags are set, their matches form one union. All exclude matches are then removed from that union, so exclusion wins. Exact IDs and prefixes are case-sensitive. Prefixes are literal text, not regular expressions or globs: use `--include-prefix sample_`, not `sample_*`. Spaces around comma-separated prefixes are trimmed; an empty prefix is an error.
+FASTA matching uses the first token after `>`. GFA1 matching uses `P` names or, in a pathless graph, `S` names. Filters reject FASTQ, BAM, and read-subset modes. Every selector must match, and an empty selection fails. See [Parameters](docs/parameters.md#assembly-record-filters) for validation and GFA limits.
 
-For FASTA, the primary ID is the first whitespace-delimited token after `>`. An NCBI header such as `>NC_000001.11 Homo sapiens chromosome 1` therefore has the ID `NC_000001.11`. Matching includes the accession version. For GFA1 with `P` records, selectors match path names. A pathless GFA1 graph uses segment names. Filtering does not remove supported original topology or excluded paths; it limits the terminal segment ends that Teloscope scans.
-
-Each `--include-bed` or `--exclude-bed` file may mix one-column ID rows and BED3+ rows. Blank lines, `#` comments, `track` lines, and `browser` lines are ignored. BED start and end fields must be unsigned integers with start no greater than end. Coordinates are validated but are not used to crop, splice, or remap a sequence: selection always applies to the whole record.
-
-Every exact ID and every prefix must match at least one ID in the input domain. Teloscope exits on an unmatched selector, duplicate FASTA primary ID, invalid selector file, or an empty final selection. It prints the selected and input counts to stderr. FASTA summary output also records both counts, and all BED, BEDgraph, TSV, and plot-report outputs contain selected records only. Filtering happens after the assembly is loaded, so it reduces scanning and output size but not input parsing or peak loader memory.
-
-These four flags apply only to FASTA and supported GFA1 assembly files. Uncompressed filtered stdin is treated as FASTA; filtered GFA input must use a `.gfa` or `.gfa.gz` filename. Filtered GFA2, GFA1 `C` containment and `W` walk records, and unknown GFA record types are rejected because the current graph writer cannot preserve them safely. Teloscope also rejects filtered FASTQ/BAM input and rejects the flags with `--fastq-subset` or `--bam-subset`.
-
-### Database FASTA names
-
-Do not treat one prefix as a universal chromosome label. In NCBI assembly packages, `GCA_...` and `GCF_...` identify the assembly; they are not the sequence IDs at the start of `*_genomic.fna` headers. Those FASTA IDs are sequence accession.version values. RefSeq families such as `NC_`, `NT_`, `NW_`, and `NZ_` describe broad record classes. GenBank/INSDC WGS accessions use project-specific four- or six-letter series, and NCBI classifies `CM` as a scaffold/CON accession family rather than a universal chromosome class. Ensembl, UCSC, and submitter FASTAs use other schemes.
-
-For a rigorous chromosome-only set, use the role and molecule type in the NCBI [genome sequence report](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/data-reports/genome-sequence/) or [assembly report](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/data-processing/policies-annotation/genomeftp/), then pass the matching sequence accessions as an exact list. In an assembly report, column 4 distinguishes chromosomes from mitochondria and other assembled molecules; column 5 matches a GenBank/GCA genomic FASTA, while column 7 matches a paired RefSeq/GCF genomic FASTA:
-
-```sh
-# GenBank/GCA FASTA IDs
-awk -F '\t' '$1 !~ /^#/ && $2 == "assembled-molecule" && $4 == "Chromosome" {print $5}' \
-  assembly_report.txt > chromosomes.ids
-
-# RefSeq/GCF FASTA IDs
-awk -F '\t' '$1 !~ /^#/ && $2 == "assembled-molecule" && $4 == "Chromosome" && $7 != "na" {print $7}' \
-  assembly_report.txt > chromosomes.ids
-
-teloscope assembly_genomic.fna.gz --include-bed chromosomes.ids -o results/
-```
-
-Use `--include-prefix` when you have inspected the actual headers and a prefix cleanly represents the set you want. NCBI’s [accession-prefix table](https://www.ncbi.nlm.nih.gov/genbank/acc_prefix/) lists INSDC formats, but the assembly/sequence role remains the safer chromosome classifier.
+For NCBI FASTA, prefer exact accession.version IDs from the [genome sequence report](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/data-reports/genome-sequence/) or [assembly report](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/data-processing/policies-annotation/genomeftp/). `GCA_` and `GCF_` name assemblies, not FASTA records, and prefixes such as `CM` or `NC_` are not universal chromosome tests.
 
 ## Typical output layout
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ For `--plot-report`, install Python 3 with `matplotlib`, `numpy`, and `pandas`.
 | Scan a vertebrate assembly with the default motif | `teloscope asm.fa` |
 | Read compressed FASTA directly | `teloscope asm.fa.gz` |
 | Write all optional FASTA outputs | `teloscope asm.fa -o results/ -r -g -e -m -i --plot-report` |
+| Keep one inspected submitter naming family | `teloscope asm.fa --include-prefix hap1_chr -o results/` |
+| Keep exact sequence IDs from a BED/list file (safest for database assemblies) | `teloscope asm.fa --include-bed chromosomes.ids -o results/` |
 | Switch to a plant canonical repeat | `teloscope asm.fa -c CCCTAAA` |
 | Search explicit motif variants | `teloscope asm.fa -c TTAGGG -p TTAGGG,TCAGGG,TGAGGG,TTGGGG` |
 | Annotate a graph for BandageNG | `teloscope asm.gfa -o results/` |
@@ -80,6 +82,49 @@ Notes:
 - `--bam-subset` writes BAM to stdout and diagnostics to stderr. Pass `-o` to write `<input_stem>_telomeric.bam`.
 - Read subset modes use a `42` bp default minimum block length; assembly annotation keeps the `300` bp default. Use `-l` to override either mode.
 - BAM support has no external bioinformatics runtime dependency: it uses `zlib` directly and does not require HTSlib, `samtools`, or another converter.
+
+## Filter assembly records
+
+Record filtering is off by default, so existing FASTA and GFA behavior is unchanged. When filtering is active, the selection domain is every FASTA record, every supported GFA1 `P` path, or every segment in a pathless GFA1 graph.
+
+| Flag | Value | Default | Effect |
+| --- | --- | --- | --- |
+| `--include-bed FILE` | BED or one-ID-per-line file | not set | keep records whose complete primary ID occurs in column 1 |
+| `--exclude-bed FILE` | BED or one-ID-per-line file | not set | remove records whose complete primary ID occurs in column 1 |
+| `--include-prefix LIST` | comma-separated literal prefixes | not set | keep records whose primary ID starts with any listed prefix |
+| `--exclude-prefix LIST` | comma-separated literal prefixes | not set | remove records whose primary ID starts with any listed prefix |
+
+The BED pair uses the familiar gfastats flag names for an auditable exact-ID workflow, but Teloscope deliberately treats column 1 as a whole-record selector. This avoids coordinate edits that could change terminal context. The options are long-only because Teloscope already uses `-i` for ITS output and `-e` for entropy output. The prefix pair handles a known accession family without forcing users to generate a list or enabling error-prone regex syntax.
+
+All four flags can be repeated. If no include flag is set, every input record starts selected. If one or more include flags are set, their matches form one union. All exclude matches are then removed from that union, so exclusion wins. Exact IDs and prefixes are case-sensitive. Prefixes are literal text, not regular expressions or globs: use `--include-prefix sample_`, not `sample_*`. Spaces around comma-separated prefixes are trimmed; an empty prefix is an error.
+
+For FASTA, the primary ID is the first whitespace-delimited token after `>`. An NCBI header such as `>NC_000001.11 Homo sapiens chromosome 1` therefore has the ID `NC_000001.11`. Matching includes the accession version. For GFA1 with `P` records, selectors match path names. A pathless GFA1 graph uses segment names. Filtering does not remove supported original topology or excluded paths; it limits the terminal segment ends that Teloscope scans.
+
+Each `--include-bed` or `--exclude-bed` file may mix one-column ID rows and BED3+ rows. Blank lines, `#` comments, `track` lines, and `browser` lines are ignored. BED start and end fields must be unsigned integers with start no greater than end. Coordinates are validated but are not used to crop, splice, or remap a sequence: selection always applies to the whole record.
+
+Every exact ID and every prefix must match at least one ID in the input domain. Teloscope exits on an unmatched selector, duplicate FASTA primary ID, invalid selector file, or an empty final selection. It prints the selected and input counts to stderr. FASTA summary output also records both counts, and all BED, BEDgraph, TSV, and plot-report outputs contain selected records only. Filtering happens after the assembly is loaded, so it reduces scanning and output size but not input parsing or peak loader memory.
+
+These four flags apply only to FASTA and supported GFA1 assembly files. Uncompressed filtered stdin is treated as FASTA; filtered GFA input must use a `.gfa` or `.gfa.gz` filename. Filtered GFA2, GFA1 `C` containment and `W` walk records, and unknown GFA record types are rejected because the current graph writer cannot preserve them safely. Teloscope also rejects filtered FASTQ/BAM input and rejects the flags with `--fastq-subset` or `--bam-subset`.
+
+### Database FASTA names
+
+Do not treat one prefix as a universal chromosome label. In NCBI assembly packages, `GCA_...` and `GCF_...` identify the assembly; they are not the sequence IDs at the start of `*_genomic.fna` headers. Those FASTA IDs are sequence accession.version values. RefSeq families such as `NC_`, `NT_`, `NW_`, and `NZ_` describe broad record classes. GenBank/INSDC WGS accessions use project-specific four- or six-letter series, and NCBI classifies `CM` as a scaffold/CON accession family rather than a universal chromosome class. Ensembl, UCSC, and submitter FASTAs use other schemes.
+
+For a rigorous chromosome-only set, use the role and molecule type in the NCBI [genome sequence report](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/data-reports/genome-sequence/) or [assembly report](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/data-processing/policies-annotation/genomeftp/), then pass the matching sequence accessions as an exact list. In an assembly report, column 4 distinguishes chromosomes from mitochondria and other assembled molecules; column 5 matches a GenBank/GCA genomic FASTA, while column 7 matches a paired RefSeq/GCF genomic FASTA:
+
+```sh
+# GenBank/GCA FASTA IDs
+awk -F '\t' '$1 !~ /^#/ && $2 == "assembled-molecule" && $4 == "Chromosome" {print $5}' \
+  assembly_report.txt > chromosomes.ids
+
+# RefSeq/GCF FASTA IDs
+awk -F '\t' '$1 !~ /^#/ && $2 == "assembled-molecule" && $4 == "Chromosome" && $7 != "na" {print $7}' \
+  assembly_report.txt > chromosomes.ids
+
+teloscope assembly_genomic.fna.gz --include-bed chromosomes.ids -o results/
+```
+
+Use `--include-prefix` when you have inspected the actual headers and a prefix cleanly represents the set you want. NCBI’s [accession-prefix table](https://www.ncbi.nlm.nih.gov/genbank/acc_prefix/) lists INSDC formats, but the assembly/sequence role remains the safer chromosome classifier.
 
 ## Typical output layout
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -101,6 +101,8 @@ Assembly Summary reports totals and counts for:
 - chromosomes with two, one, or zero telomeres
 - each scaffold class
 
+When an assembly record filter is active, the summary also reports the number of input and selected paths. `Total paths` and every other statistic describe the selected paths only.
+
 ## GFA mode output
 
 GFA mode writes the original graph plus synthetic telomere segments connected back to the carrier segment with `L telomere_...` links at `0M` overlap. It also writes `<input>.telo.annotated.colors.csv`, which paints every cap green (`#008000`) for BandageNG.
@@ -111,9 +113,9 @@ Each synthetic telomere segment includes:
 - `RC:i:6000`
 - `TL:i:<detected_block_length_bp>`
 
-Each telomere link points from the synthetic node (`+`) to the assembly segment, with the segment-side orientation set so the cap sits on the correct physical end (`+` at a start, `-` at an end), and carries `RC:i:0`. `J` jump records stay reserved for real assembly gaps. When paths are present, only path-terminal segment ends are annotated and the orientation follows the path context. When no paths are present, segments are scanned independently.
+Each telomere link points from the synthetic node (`+`) to the assembly segment, with the segment-side orientation set so the cap sits on the correct physical end (`+` at a start, `-` at an end), and carries `RC:i:0`. `J` jump records stay reserved for real assembly gaps. With GFA1 `P` paths, only terminal segment ends reached from selected paths are scanned and orientation follows the path context. In a pathless GFA1 graph, selected segments are scanned independently. Caps are graph-level, so a shared annotated segment end is visible from selected and excluded paths. Filtered GFA2, GFA1 `C` containment and `W` walk records, and unknown GFA record types are rejected.
 
-No BED, BEDgraph, or TSV files are written in GFA mode.
+No BED, BEDgraph, or TSV files are written in GFA mode. Record filters do not delete supported original graph records; they limit which terminal segment ends Teloscope scans for new annotations.
 
 ## BAM subset output
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -29,6 +29,31 @@ teloscope --bam-subset input.bam [options] > telomeric.bam
 |  | `--fastq-subset` | stream FASTQ reads with Teloscope-valid telomeric blocks to stdout, or to a file with `-o` | `false` |
 |  | `--bam-subset` | stream BAM records with Teloscope-valid telomeric blocks to stdout, or to a file with `-o` | `false` |
 
+## Assembly record filters
+
+| Long form | Value | Meaning | Default |
+| --- | --- | --- | --- |
+| `--include-bed FILE` | BED or one-ID-per-line file | analyze whole records whose exact primary IDs occur in column 1 | unset |
+| `--exclude-bed FILE` | BED or one-ID-per-line file | exclude whole records whose exact primary IDs occur in column 1 | unset |
+| `--include-prefix LIST` | comma-separated literal prefixes | analyze IDs that start with any listed prefix | unset |
+| `--exclude-prefix LIST` | comma-separated literal prefixes | exclude IDs that start with any listed prefix | unset |
+
+Exact files keep metadata-derived selections explicit and auditable. Prefix lists cover known accession families without requiring a generated file or regular-expression syntax. These options are long-only because `-i` and `-e` already control ITS and entropy output.
+
+Filtering is off when all four options are unset. With no include option, every record starts selected. Repeated include files and prefix lists form one union. All exclusion matches are removed afterward, so exclusion wins. Exact IDs and prefixes are case-sensitive. Prefixes are literal strings, not globs or regular expressions; use `sample_`, not `sample_*`.
+
+For FASTA, matching uses the first whitespace-delimited token after `>`, including an accession version such as `.11`. For GFA1 `P` records, matching uses path names. A pathless GFA1 graph uses segment names.
+
+Selector files may mix one-column ID rows and BED3+ rows. Blank lines, `#` comments, `track` lines, and `browser` lines are skipped. BED start and end must be unsigned integers with start no greater than end. Coordinates are validated but never crop, join, or remap a sequence; selection always applies to the complete record.
+
+Every exact ID and every prefix must match at least one input-domain ID. Teloscope exits on an unmatched selector, duplicate FASTA primary ID, invalid or empty selector file, invalid BED coordinates, or an empty final selection. It reports the selected and input counts to stderr and in the FASTA summary.
+
+Filtering a GFA does not delete supported original graph records. It scans terminal segment ends reached from selected paths, or selected segments in a pathless graph. Caps and links are graph-level annotations, so an annotated segment end shared by selected and excluded paths is visible to both. Filtered GFA2, GFA1 `C` containment and `W` walk records, and unknown GFA record types are rejected because the current writer cannot preserve them safely.
+
+Filtering happens after the assembly is loaded. It reduces scanning and output size, including `--plot-report`, but not input parsing or peak loader memory. Filters require FASTA or supported GFA1 input; uncompressed filtered stdin is treated as FASTA, and filtered GFA input must use a `.gfa` or `.gfa.gz` filename. Filtered FASTQ/BAM input and both read-subset modes are rejected.
+
+Database prefixes are format-specific. `GCA_` and `GCF_` are NCBI assembly accessions, not sequence IDs. `CM` is a GenBank/INSDC scaffold/CON family rather than a universal chromosome label, and `NC_` works only when that text starts the actual FASTA primary ID. For chromosome-only selection, prefer exact accession.version IDs derived from the NCBI sequence or assembly report. See [Database FASTA names](../README.md#database-fasta-names).
+
 ## Pattern control
 
 | Flag | Long form | Meaning | Default |
@@ -92,6 +117,24 @@ Default vertebrate run:
 
 ```sh
 teloscope asm.fa
+```
+
+One inspected submitter naming family:
+
+```sh
+teloscope asm.fa --include-prefix hap1_chr -o results/
+```
+
+Exact chromosome IDs derived from assembly metadata:
+
+```sh
+teloscope asm.fa --include-bed chromosomes.ids -o results/
+```
+
+Exact include list with a final exclusion list:
+
+```sh
+teloscope asm.fa --include-bed primary.ids --exclude-bed do_not_plot.ids -o results/
 ```
 
 Plant canonical repeat:

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -33,26 +33,24 @@ teloscope --bam-subset input.bam [options] > telomeric.bam
 
 | Long form | Value | Meaning | Default |
 | --- | --- | --- | --- |
-| `--include-bed FILE` | BED or one-ID-per-line file | analyze whole records whose exact primary IDs occur in column 1 | unset |
-| `--exclude-bed FILE` | BED or one-ID-per-line file | exclude whole records whose exact primary IDs occur in column 1 | unset |
-| `--include-prefix LIST` | comma-separated literal prefixes | analyze IDs that start with any listed prefix | unset |
-| `--exclude-prefix LIST` | comma-separated literal prefixes | exclude IDs that start with any listed prefix | unset |
+| `--include-bed` | `FILE` | keep IDs listed in column 1 | unset |
+| `--exclude-bed` | `FILE` | remove IDs listed in column 1 | unset |
+| `--include-prefix` | `LIST` | keep IDs with any comma-separated prefix | unset |
+| `--exclude-prefix` | `LIST` | remove IDs with any comma-separated prefix | unset |
 
-Exact files keep metadata-derived selections explicit and auditable. Prefix lists cover known accession families without requiring a generated file or regular-expression syntax. These options are long-only because `-i` and `-e` already control ITS and entropy output.
+Filtering is off when all four flags are unset. Flags can be repeated. Includes form a union and exclusions run last; without includes, all records start selected. Matching is case-sensitive, and prefixes are literal strings rather than globs or regular expressions.
 
-Filtering is off when all four options are unset. With no include option, every record starts selected. Repeated include files and prefix lists form one union. All exclusion matches are removed afterward, so exclusion wins. Exact IDs and prefixes are case-sensitive. Prefixes are literal strings, not globs or regular expressions; use `sample_`, not `sample_*`.
+FASTA matching uses the first token after `>`, including accession versions. GFA1 matching uses `P` path names or `S` segment names when no paths exist.
 
-For FASTA, matching uses the first whitespace-delimited token after `>`, including an accession version such as `.11`. For GFA1 `P` records, matching uses path names. A pathless GFA1 graph uses segment names.
+Selector files accept one-ID rows or BED3+ rows and skip blank, `#`, `track`, and `browser` lines. BED coordinates must be unsigned integers with start no greater than end, but they never crop or remap a sequence.
 
-Selector files may mix one-column ID rows and BED3+ rows. Blank lines, `#` comments, `track` lines, and `browser` lines are skipped. BED start and end must be unsigned integers with start no greater than end. Coordinates are validated but never crop, join, or remap a sequence; selection always applies to the complete record.
+Every exact ID and prefix must match at least one input name. Teloscope rejects unmatched selectors, duplicate FASTA IDs, invalid or empty selector files, invalid BED coordinates, and empty final selections. It reports selected and input counts to stderr and in the FASTA summary.
 
-Every exact ID and every prefix must match at least one input-domain ID. Teloscope exits on an unmatched selector, duplicate FASTA primary ID, invalid or empty selector file, invalid BED coordinates, or an empty final selection. It reports the selected and input counts to stderr and in the FASTA summary.
+Filters require FASTA or supported GFA1 input. GFA filtering preserves supported graph records and only limits scanned terminal ends. Filtered GFA accepts `H`, `S`, `L`, `J`, and `P` records; it rejects GFA2, `C`, `W`, and unknown records. Filtered stdin is parsed as FASTA, so GFA input needs a `.gfa` or `.gfa.gz` filename. FASTQ, BAM, and both read-subset modes reject filters.
 
-Filtering a GFA does not delete supported original graph records. It scans terminal segment ends reached from selected paths, or selected segments in a pathless graph. Caps and links are graph-level annotations, so an annotated segment end shared by selected and excluded paths is visible to both. Filtered GFA2, GFA1 `C` containment and `W` walk records, and unknown GFA record types are rejected because the current writer cannot preserve them safely.
+Filtering occurs after input loading. It reduces scanning and output size, including `--plot-report`, but not parsing or peak memory. FASTA BED, BEDgraph, TSV, and report outputs contain selected records only.
 
-Filtering happens after the assembly is loaded. It reduces scanning and output size, including `--plot-report`, but not input parsing or peak loader memory. Filters require FASTA or supported GFA1 input; uncompressed filtered stdin is treated as FASTA, and filtered GFA input must use a `.gfa` or `.gfa.gz` filename. Filtered FASTQ/BAM input and both read-subset modes are rejected.
-
-Database prefixes are format-specific. `GCA_` and `GCF_` are NCBI assembly accessions, not sequence IDs. `CM` is a GenBank/INSDC scaffold/CON family rather than a universal chromosome label, and `NC_` works only when that text starts the actual FASTA primary ID. For chromosome-only selection, prefer exact accession.version IDs derived from the NCBI sequence or assembly report. See [Database FASTA names](../README.md#database-fasta-names).
+For database FASTA, use exact accession.version IDs from the NCBI [genome sequence report](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/data-reports/genome-sequence/) or [assembly report](https://www.ncbi.nlm.nih.gov/datasets/docs/v2/data-processing/policies-annotation/genomeftp/). `GCA_` and `GCF_` are assembly accessions, and prefixes such as `CM` or `NC_` are not universal chromosome rules. Use prefixes only after checking the input headers.
 
 ## Pattern control
 
@@ -119,22 +117,11 @@ Default vertebrate run:
 teloscope asm.fa
 ```
 
-One inspected submitter naming family:
-
-```sh
-teloscope asm.fa --include-prefix hap1_chr -o results/
-```
-
-Exact chromosome IDs derived from assembly metadata:
-
-```sh
-teloscope asm.fa --include-bed chromosomes.ids -o results/
-```
-
-Exact include list with a final exclusion list:
+Filter assembly records:
 
 ```sh
 teloscope asm.fa --include-bed primary.ids --exclude-bed do_not_plot.ids -o results/
+teloscope asm.fa --include-prefix hap1_chr,hap2_chr -o results/
 ```
 
 Plant canonical repeat:

--- a/docs/report.md
+++ b/docs/report.md
@@ -12,6 +12,14 @@ This writes `results/asm.fa_plot_report.pdf`.
 
 `-r` is recommended with `--plot-report` so the report includes repeat-density, canonical-ratio, and strand-bias tracks. GC and entropy tracks are added automatically when their files are present.
 
+Assembly record filters apply before these files are written. This example uses exact chromosome accession.version IDs derived from assembly metadata and omits every other record from the TSV, BED/BEDgraph files, and PDF:
+
+```sh
+teloscope asm.fa -o results/ --include-bed chromosomes.ids -r --plot-report
+```
+
+Prefix filters are also available, but database prefixes are not universal chromosome labels. Inspect the FASTA primary IDs before using `--include-prefix`.
+
 ## What the report contains
 
 - page 1: assembly overview, scaffold classes, and flagged scaffolds

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -89,6 +89,14 @@ bash scripts/test_gaps_bed.sh
 
 This script compares generated `*_gaps.bed` files against the checked-in expected files in `testFiles/expected/`.
 
+## Assembly record filter regression script
+
+```sh
+make test-filters
+```
+
+This builds temporary FASTA and GFA fixtures and checks exact-ID and prefix selection, include/exclude precedence, selector validation, compressed input, line endings, unsupported modes, and output isolation. The CI workflow runs the same script on Linux, macOS, and Windows.
+
 ## BAM subset regression script
 
 ```sh

--- a/include/input.h
+++ b/include/input.h
@@ -18,6 +18,13 @@ struct UserInputTeloscope : UserInput {
     std::string inSequenceName;
     std::string outRoute;
     bool outRouteSet = false;
+    std::vector<std::string> includeBedFiles;
+    std::vector<std::string> excludeBedFiles;
+    std::vector<std::string> includePrefixes;
+    std::vector<std::string> excludePrefixes;
+    bool sequenceFilterActive = false;
+    uint64_t filterInputCount = 0;
+    uint64_t filterSelectedCount = 0;
     std::unordered_map<std::string, uint8_t> hammingDistances;
 
     std::string canonicalFwd = "CCCTAA";

--- a/scripts/test_sequence_filters.py
+++ b/scripts/test_sequence_filters.py
@@ -1,0 +1,783 @@
+#!/usr/bin/env python3
+
+import gzip
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_TELOSCOPE = ROOT / "build/bin" / ("teloscope.exe" if os.name == "nt" else "teloscope")
+TELOSCOPE = pathlib.Path(os.environ.get("TELOSCOPE", DEFAULT_TELOSCOPE))
+MULTI_FASTA = ROOT / "testFiles" / "multi.fa"
+PATH_GFA = ROOT / "testFiles" / "gfa_path_orient_pairs_small.gfa"
+PATHLESS_GFA = ROOT / "testFiles" / "gfa_pathless_small.gfa"
+SHARED_GFA = ROOT / "testFiles" / "gfa_single_seg_paths_small.gfa"
+LARGE_GZIP_FASTA = ROOT / "testFiles" / "bTaeGut7_chr33_mat.fa.gz"
+
+
+def require(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def decode(data):
+    return data.decode("utf-8", errors="replace")
+
+
+def run(args, stdin=None):
+    try:
+        return subprocess.run(
+            [str(TELOSCOPE), *[str(arg) for arg in args]],
+            input=stdin,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=60,
+        )
+    except subprocess.TimeoutExpired as error:
+        raise AssertionError(f"Teloscope timed out: {' '.join(str(arg) for arg in args)}") from error
+
+
+def require_success(result, context):
+    require(
+        result.returncode == 0,
+        f"{context} failed with exit {result.returncode}\nstdout:\n{decode(result.stdout)}"
+        f"\nstderr:\n{decode(result.stderr)}",
+    )
+
+
+def require_failure(result, context, expected=None):
+    require(result.returncode != 0, f"{context} unexpectedly succeeded")
+    if expected is not None:
+        combined = decode(result.stdout) + decode(result.stderr)
+        require(expected in combined, f"{context} lacked diagnostic {expected!r}:\n{combined}")
+
+
+def parse_report_names(text):
+    names = []
+    for line in text.splitlines():
+        fields = line.split("\t")
+        if len(fields) >= 2 and fields[0].isdigit():
+            names.append(fields[1])
+    return names
+
+
+def parse_report_table(text):
+    header = None
+    rows = []
+    for line in text.splitlines():
+        fields = line.split("\t")
+        if len(fields) >= 2 and fields[:2] == ["pos", "header"]:
+            header = fields
+        elif len(fields) >= 2 and fields[0].isdigit():
+            rows.append(fields)
+    require(header is not None, "tabular report header is absent")
+    for fields in rows:
+        require(
+            len(fields) == len(header),
+            f"tabular report row changed schema ({len(fields)} fields, expected {len(header)}): {fields}",
+        )
+    return header, rows
+
+
+def summary_value(text, label):
+    prefix = f"{label}:\t"
+    for line in text.splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix):]
+    raise AssertionError(f"summary field {label!r} was absent")
+
+
+def only_report(out_dir):
+    reports = sorted(out_dir.glob("*_report.tsv"))
+    require(len(reports) == 1, f"expected one report in {out_dir}, found {reports}")
+    return reports[0]
+
+
+def assert_fasta_selection(result, out_dir, expected_names, input_count):
+    require_success(result, "filtered FASTA run")
+    expected_names = list(expected_names)
+    stdout = decode(result.stdout)
+    stderr = decode(result.stderr)
+    report = only_report(out_dir).read_text(encoding="utf-8")
+
+    parse_report_table(stdout)
+    parse_report_table(report)
+    require(parse_report_names(stdout) == expected_names, "stdout contains the wrong selected record order")
+    require(parse_report_names(report) == expected_names, "report contains the wrong selected record order")
+    require(
+        f"Sequence filter: selected {len(expected_names)} of {input_count} paths." in stderr,
+        "stderr selection count is missing or wrong",
+    )
+    require(summary_value(stdout, "Total paths") == str(len(expected_names)), "Total paths is wrong")
+    require(summary_value(stdout, "Filter input paths") == str(input_count), "input count is wrong")
+    require(
+        summary_value(stdout, "Filter selected paths") == str(len(expected_names)),
+        "selected count is wrong",
+    )
+
+
+def assert_excluded_absent(out_dir, excluded_names):
+    outputs = sorted(
+        path for path in out_dir.iterdir()
+        if path.suffix in {".bed", ".bedgraph", ".tsv"}
+    )
+    require(outputs, f"no text outputs found in {out_dir}")
+    for path in outputs:
+        text = path.read_text(encoding="utf-8")
+        for name in excluded_names:
+            require(name not in text, f"excluded ID {name!r} leaked into {path.name}")
+
+
+def run_fasta(fasta, out_dir, options):
+    return run(["-f", fasta, "-o", out_dir, "-j", "1", *options])
+
+
+def read_fasta(path):
+    records = []
+    header = None
+    sequence = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.startswith(">"):
+            if header is not None:
+                records.append((header, "".join(sequence)))
+            header = line[1:]
+            sequence = []
+        else:
+            sequence.append(line.strip())
+    if header is not None:
+        records.append((header, "".join(sequence)))
+    return records
+
+
+def write_fasta(path, records):
+    with path.open("w", encoding="utf-8", newline="\n") as stream:
+        for header, sequence in records:
+            stream.write(f">{header}\n{sequence}\n")
+
+
+def test_exact_id_and_all_text_outputs(tmp):
+    out_dir = tmp / "exact_out"
+    selector = tmp / "include.ids"
+    selector.write_text("contig_t2t\n", encoding="utf-8")
+    result = run_fasta(
+        MULTI_FASTA,
+        out_dir,
+        ["--include-bed", selector, "-r", "-g", "-e", "-m", "-i"],
+    )
+
+    assert_fasta_selection(result, out_dir, ["contig_t2t"], 3)
+    assert_excluded_absent(out_dir, ["contig_none", "contig_incomplete"])
+    density = out_dir / "multi.fa_window_repeat_density.bedgraph"
+    require(density.exists(), "repeat-density output was not generated")
+    density_ids = {
+        fields[0]
+        for line in density.read_text(encoding="utf-8").splitlines()
+        if len(fields := line.split("\t")) >= 4
+    }
+    require(density_ids == {"contig_t2t"}, "BEDgraph contains an unselected record")
+
+
+def test_bed3_comments_directives_crlf_and_duplicates(tmp):
+    out_dir = tmp / "bed3_out"
+    selector = tmp / "include.bed"
+    selector.write_bytes(
+        b"# generated selector\r\n"
+        b"\r\n"
+        b"track name=selected\r\n"
+        b"browser position contig_t2t:1-10\r\n"
+        b"contig_t2t\t0\t0\r\n"
+        b"contig_t2t\t0\t100\textra\r\n"
+    )
+    result = run_fasta(MULTI_FASTA, out_dir, ["--include-bed", selector])
+    assert_fasta_selection(result, out_dir, ["contig_t2t"], 3)
+
+    bom_selector = tmp / "bom.ids"
+    bom_selector.write_bytes(b"\xef\xbb\xbfcontig_t2t\r\n")
+    bom_out = tmp / "bom_out"
+    bom_result = run_fasta(MULTI_FASTA, bom_out, ["--include-bed", bom_selector])
+    assert_fasta_selection(bom_result, bom_out, ["contig_t2t"], 3)
+
+
+def test_include_union_repetition_and_exclusion_precedence(tmp):
+    include_t2t = tmp / "include_t2t.ids"
+    include_incomplete = tmp / "include_incomplete.bed"
+    exclude_t2t = tmp / "exclude_t2t.ids"
+    include_t2t.write_text("contig_t2t\ncontig_t2t\n", encoding="utf-8")
+    include_incomplete.write_text("contig_incomplete\t0\t1\n", encoding="utf-8")
+    exclude_t2t.write_text("contig_t2t\n", encoding="utf-8")
+
+    union_out = tmp / "union_out"
+    union_result = run_fasta(
+        MULTI_FASTA,
+        union_out,
+        [
+            "--include-bed", include_t2t,
+            "--include-bed", include_incomplete,
+            "--include-bed", include_t2t,
+            "--include-prefix", " contig_inc , contig_t2 ",
+            "--include-prefix", "contig_inc",
+            "--exclude-prefix", " contig_none ",
+        ],
+    )
+    assert_fasta_selection(union_result, union_out, ["contig_t2t", "contig_incomplete"], 3)
+
+    subtract_out = tmp / "subtract_out"
+    subtract_result = run_fasta(
+        MULTI_FASTA,
+        subtract_out,
+        [
+            "--include-bed", include_t2t,
+            "--include-bed", include_incomplete,
+            "--exclude-bed", exclude_t2t,
+        ],
+    )
+    assert_fasta_selection(subtract_result, subtract_out, ["contig_incomplete"], 3)
+
+    exclude_only_out = tmp / "exclude_only_out"
+    exclude_only_result = run_fasta(
+        MULTI_FASTA,
+        exclude_only_out,
+        ["--exclude-prefix", "contig_none"],
+    )
+    assert_fasta_selection(
+        exclude_only_result,
+        exclude_only_out,
+        ["contig_t2t", "contig_incomplete"],
+        3,
+    )
+
+
+def test_prefixes_are_trimmed_literal_and_case_sensitive(tmp):
+    source_records = read_fasta(MULTI_FASTA)
+    sequences = [sequence for _, sequence in source_records]
+    fasta = tmp / "prefixes.fa"
+    write_fasta(
+        fasta,
+        [
+            ("CM.alpha chromosome one", sequences[0]),
+            ("CMXalpha chromosome two", sequences[1]),
+            ("cm.alpha lower case", sequences[2]),
+            ("star*one literal wildcard", sequences[0]),
+        ],
+    )
+
+    dot_out = tmp / "literal_dot_out"
+    dot_result = run_fasta(fasta, dot_out, ["--include-prefix", "CM."])
+    assert_fasta_selection(dot_result, dot_out, ["CM.alpha"], 4)
+
+    case_out = tmp / "case_out"
+    case_result = run_fasta(fasta, case_out, ["--include-prefix", "cm."])
+    assert_fasta_selection(case_result, case_out, ["cm.alpha"], 4)
+
+    grouped_out = tmp / "grouped_out"
+    grouped_result = run_fasta(
+        fasta,
+        grouped_out,
+        ["--include-prefix", " star* , CM. ", "--include-prefix", "CM."],
+    )
+    assert_fasta_selection(grouped_result, grouped_out, ["CM.alpha", "star*one"], 4)
+
+
+def test_fasta_primary_ids_with_crlf_and_tab_descriptions(tmp):
+    source_records = read_fasta(MULTI_FASTA)
+    sequences = [sequence.encode() for _, sequence in source_records]
+
+    crlf_fasta = tmp / "crlf.fa"
+    crlf_fasta.write_bytes(
+        b">CMCRLF\r\n" + sequences[0] + b"\r\n"
+        b">NWCRLF\r\n" + sequences[1] + b"\r\n"
+    )
+    crlf_selector = _write(tmp / "crlf.ids", "CMCRLF\n")
+    crlf_out = tmp / "crlf_out"
+    crlf_result = run_fasta(crlf_fasta, crlf_out, ["--include-bed", crlf_selector])
+    assert_fasta_selection(crlf_result, crlf_out, ["CMCRLF"], 2)
+    expected_length = str(len(sequences[0]))
+    require(
+        summary_value(decode(crlf_result.stdout), "Scaffold N50") == expected_length,
+        "CRLF changed the selected scaffold length",
+    )
+    require(
+        summary_value(decode(crlf_result.stdout), "Contig N50") == expected_length,
+        "CRLF changed the selected contig length",
+    )
+
+    terminal_records = [
+        (b"CM_terminal_N", b"ACGT" * 400 + b"N"),
+        (b"CM_terminal_X", b"TGCA" * 400 + b"X"),
+    ]
+    lf_terminal = tmp / "terminal_lf.fa"
+    crlf_terminal = tmp / "terminal_crlf.fa"
+    lf_terminal.write_bytes(
+        b"".join(b">" + name + b"\n" + sequence + b"\n" for name, sequence in terminal_records)
+    )
+    crlf_terminal.write_bytes(
+        b"".join(b">" + name + b"\r\n" + sequence + b"\r\n" for name, sequence in terminal_records)
+    )
+    lf_out = tmp / "terminal_lf_out"
+    crlf_terminal_out = tmp / "terminal_crlf_out"
+    lf_result = run_fasta(lf_terminal, lf_out, ["--include-prefix", "CM_terminal_"])
+    crlf_terminal_result = run_fasta(
+        crlf_terminal,
+        crlf_terminal_out,
+        ["--include-prefix", "CM_terminal_"],
+    )
+    terminal_names = ["CM_terminal_N", "CM_terminal_X"]
+    assert_fasta_selection(lf_result, lf_out, terminal_names, 2)
+    assert_fasta_selection(crlf_terminal_result, crlf_terminal_out, terminal_names, 2)
+    for label in ("Total gaps", "Scaffold N50", "Contig N50"):
+        require(
+            summary_value(decode(crlf_terminal_result.stdout), label)
+            == summary_value(decode(lf_result.stdout), label),
+            f"CRLF changed {label} for a terminal N/X record",
+        )
+    require(
+        parse_report_table(only_report(crlf_terminal_out).read_text(encoding="utf-8"))
+        == parse_report_table(only_report(lf_out).read_text(encoding="utf-8")),
+        "CRLF changed report classification or component counts for terminal N/X records",
+    )
+    lf_gaps = next(lf_out.glob("*_gaps.bed")).read_text(encoding="utf-8")
+    crlf_gaps = next(crlf_terminal_out.glob("*_gaps.bed")).read_text(encoding="utf-8")
+    require(crlf_gaps == lf_gaps, "CRLF changed terminal N/X gap coordinates")
+
+    tab_fasta = tmp / "tab_header.fa"
+    tab_fasta.write_bytes(
+        b">CMTAB\tdescription with tabs\n" + sequences[0] + b"\n"
+        b">NWTAB\tdescription with tabs\n" + sequences[1] + b"\n"
+    )
+    tab_selector = _write(tmp / "tab.ids", "CMTAB\n")
+    tab_out = tmp / "tab_out"
+    tab_result = run_fasta(tab_fasta, tab_out, ["--include-bed", tab_selector])
+    assert_fasta_selection(tab_result, tab_out, ["CMTAB"], 2)
+    tab_report = only_report(tab_out).read_text(encoding="utf-8")
+    header, rows = parse_report_table(tab_report)
+    require(len(rows) == 1, "tab-description FASTA should produce one selected report row")
+    require(rows[0][header.index("header")] == "CMTAB", "FASTA description leaked into the report ID")
+
+    duplicate_fasta = tmp / "duplicate_primary_ids.fa"
+    duplicate_fasta.write_bytes(
+        b">dup first description\n" + sequences[0] + b"\n"
+        b">dup\tsecond description\n" + sequences[1] + b"\n"
+    )
+    duplicate_selector = _write(tmp / "duplicate.ids", "dup\n")
+    duplicate_result = run_fasta(
+        duplicate_fasta,
+        tmp / "duplicate_out",
+        ["--include-bed", duplicate_selector],
+    )
+    require_failure(duplicate_result, "duplicate normalized FASTA primary IDs")
+    duplicate_diagnostic = (decode(duplicate_result.stdout) + decode(duplicate_result.stderr)).lower()
+    require("dup" in duplicate_diagnostic, "duplicate-ID diagnostic did not name the colliding ID")
+    require(
+        "duplicate" in duplicate_diagnostic or "already exists" in duplicate_diagnostic,
+        "duplicate-ID failure lacked a clear diagnostic",
+    )
+
+
+def test_wrapped_gap_lf_crlf_parity(tmp):
+    lf_fasta = tmp / "wrapped_lf.fa"
+    crlf_fasta = tmp / "wrapped_crlf.fa"
+    lf_fasta.write_bytes(b">CMgap\nCCCTAANNN\nNNNTTAGGG\n")
+    crlf_fasta.write_bytes(b">CMgap\r\nCCCTAANNN\r\nNNNTTAGGG\r\n")
+
+    lf_out = tmp / "wrapped_lf_out"
+    crlf_out = tmp / "wrapped_crlf_out"
+    lf_result = run_fasta(lf_fasta, lf_out, ["--include-prefix", "CMgap"])
+    crlf_result = run_fasta(crlf_fasta, crlf_out, ["--include-prefix", "CMgap"])
+    assert_fasta_selection(lf_result, lf_out, ["CMgap"], 1)
+    assert_fasta_selection(crlf_result, crlf_out, ["CMgap"], 1)
+
+    for label in ("Total gaps", "Scaffold N50", "Contig N50"):
+        require(
+            summary_value(decode(crlf_result.stdout), label)
+            == summary_value(decode(lf_result.stdout), label),
+            f"wrapped CRLF input changed {label}",
+        )
+    require(summary_value(decode(crlf_result.stdout), "Total gaps") == "1", "wrapped N run split into multiple gaps")
+    require(summary_value(decode(crlf_result.stdout), "Scaffold N50") == "18", "wrapped CRLF scaffold length is wrong")
+    require(summary_value(decode(crlf_result.stdout), "Contig N50") == "6", "wrapped CRLF contig N50 is wrong")
+
+    lf_report = parse_report_table(only_report(lf_out).read_text(encoding="utf-8"))
+    crlf_report = parse_report_table(only_report(crlf_out).read_text(encoding="utf-8"))
+    require(crlf_report == lf_report, "wrapped CRLF input changed the report row")
+    lf_gaps = next(lf_out.glob("*_gaps.bed")).read_text(encoding="utf-8")
+    crlf_gaps = next(crlf_out.glob("*_gaps.bed")).read_text(encoding="utf-8")
+    require(lf_gaps == "CMgap\t6\t12\n", f"wrapped LF gap coordinates are wrong: {lf_gaps!r}")
+    require(crlf_gaps == lf_gaps, "wrapped CRLF input changed gap coordinates")
+
+
+def test_plain_gzip_and_stdin_parity(tmp):
+    payload = MULTI_FASTA.read_bytes()
+    compressed = tmp / "multi.fa.gz"
+    with gzip.open(compressed, "wb") as stream:
+        stream.write(payload)
+
+    plain_out = tmp / "plain_out"
+    plain = run_fasta(MULTI_FASTA, plain_out, ["--include-prefix", "contig_t2t"])
+    assert_fasta_selection(plain, plain_out, ["contig_t2t"], 3)
+
+    gzip_out = tmp / "gzip_out"
+    zipped = run_fasta(compressed, gzip_out, ["--include-prefix", "contig_t2t"])
+    assert_fasta_selection(zipped, gzip_out, ["contig_t2t"], 3)
+
+    stdin_out = tmp / "stdin_out"
+    piped = run(
+        ["-o", stdin_out, "-j", "1", "--include-prefix", "contig_t2t"],
+        stdin=payload,
+    )
+    assert_fasta_selection(piped, stdin_out, ["contig_t2t"], 3)
+    require(only_report(stdin_out).name == "stdin_report.tsv", "stdin output basename changed")
+
+    for result in (zipped, piped):
+        require(
+            summary_value(decode(result.stdout), "Scaffold N50")
+            == summary_value(decode(plain.stdout), "Scaffold N50"),
+            "plain/gzip/stdin filtering changed selected assembly statistics",
+        )
+
+
+def test_large_gzip_fasta_is_not_truncated_or_stalled(tmp):
+    out_dir = tmp / "large_gzip_out"
+    result = run_fasta(
+        LARGE_GZIP_FASTA,
+        out_dir,
+        ["--include-prefix", "chr33_mat", "-u"],
+    )
+    assert_fasta_selection(result, out_dir, ["chr33_mat"], 1)
+    require(
+        summary_value(decode(result.stdout), "Scaffold N50") == "4246341",
+        "large gzip FASTA was truncated",
+    )
+
+
+def test_selector_validation_failures(tmp):
+    malformed = {
+        "empty": (b"", "contains no sequence IDs"),
+        "directives_only": (
+            b"# no IDs\ntrack name=none\nbrowser position contig_t2t:1-2\n",
+            "contains no sequence IDs",
+        ),
+        "two_columns": (b"contig_t2t\t0\n", "must contain either one ID column or at least three BED columns"),
+        "negative_start": (b"contig_t2t\t-1\t2\n", "invalid BED start/end coordinates"),
+        "non_numeric": (b"contig_t2t\tzero\t2\n", "invalid BED start/end coordinates"),
+        "overflow": (b"contig_t2t\t18446744073709551616\t18446744073709551616\n", "invalid BED start/end coordinates"),
+        "reversed": (b"contig_t2t\t3\t2\n", "invalid BED start/end coordinates"),
+    }
+    for name, (contents, diagnostic) in malformed.items():
+        selector = tmp / f"{name}.bed"
+        selector.write_bytes(contents)
+        result = run_fasta(MULTI_FASTA, tmp / f"{name}_out", ["--include-bed", selector])
+        require_failure(result, name, diagnostic)
+
+    missing = tmp / "does_not_exist.bed"
+    result = run_fasta(MULTI_FASTA, tmp / "missing_out", ["--include-bed", missing])
+    require_failure(result, "missing selector")
+    require(result.stdout == b"", "missing selector diagnostic polluted stdout")
+    require("--include-bed" in decode(result.stderr), "missing selector diagnostic omitted the option name")
+    require("does not exist" in decode(result.stderr), "missing selector lacked a stderr diagnostic")
+
+    unmatched_id = tmp / "unmatched.ids"
+    unmatched_id.write_text("absent_record\n", encoding="utf-8")
+    result = run_fasta(MULTI_FASTA, tmp / "unmatched_id_out", ["--include-bed", unmatched_id])
+    require_failure(result, "unmatched exact ID", "matched no input paths")
+
+    result = run_fasta(MULTI_FASTA, tmp / "unmatched_exclude_out", ["--exclude-bed", unmatched_id])
+    require_failure(result, "unmatched exact exclusion ID", "matched no input paths")
+
+    result = run_fasta(
+        MULTI_FASTA,
+        tmp / "unmatched_prefix_out",
+        ["--include-prefix", "absent_prefix"],
+    )
+    require_failure(result, "unmatched prefix", "matched no input paths")
+
+    result = run_fasta(MULTI_FASTA, tmp / "empty_selection_out", ["--exclude-prefix", "contig_"])
+    require_failure(result, "all records excluded", "excluded all input paths")
+
+    overlap = _write(tmp / "overlap.ids", "contig_t2t\n")
+    result = run_fasta(
+        MULTI_FASTA,
+        tmp / "overlap_out",
+        ["--include-bed", overlap, "--exclude-bed", overlap],
+    )
+    require_failure(result, "include/exclude overlap", "excluded all input paths")
+
+    for index, value in enumerate(("", ",contig", "contig,,none", "contig,  ,none", "contig,")):
+        result = run_fasta(
+            MULTI_FASTA,
+            tmp / f"empty_prefix_{index}_out",
+            ["--include-prefix", value],
+        )
+        require_failure(result, f"empty prefix token {value!r}", "contains an empty prefix")
+
+
+def gfa_lines(path):
+    return [line for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+def gfa_telomere_nodes(lines):
+    return {
+        fields[1]
+        for line in lines
+        if len(fields := line.split("\t")) >= 2
+        and fields[0] == "S"
+        and fields[1].startswith("telomere_")
+    }
+
+
+def assert_original_gfa_records_preserved(input_path, output_lines, exact_types):
+    original = gfa_lines(input_path)
+    output_set = set(output_lines)
+    for line in original:
+        if line.split("\t", 1)[0] in exact_types:
+            require(line in output_set, f"original GFA record was not preserved: {line}")
+
+
+def assert_colors_match_nodes(out_dir, nodes):
+    colors_files = sorted(out_dir.glob("*.telo.annotated.colors.csv"))
+    require(len(colors_files) == 1, "expected one GFA colors file")
+    rows = colors_files[0].read_text(encoding="utf-8").splitlines()
+    require(rows and rows[0] == "node\tcolor", "GFA colors header is wrong")
+    colored_nodes = {row.split("\t", 1)[0] for row in rows[1:] if row}
+    require(colored_nodes == nodes, "colors file and annotated telomere nodes disagree")
+
+
+def test_gfa_path_filtering_and_preservation(tmp):
+    out_dir = tmp / "gfa_path_out"
+    result = run_fasta(
+        PATH_GFA,
+        out_dir,
+        ["--include-bed", _write(tmp / "paths.ids", "path_pp\n"), "-x", "0", "-l", "60"],
+    )
+    require_success(result, "path-aware GFA filter")
+    require("selected 1 of 2 paths" in decode(result.stderr), "path-aware GFA count is wrong")
+
+    outputs = sorted(out_dir.glob("*.telo.annotated.gfa"))
+    require(len(outputs) == 1, "expected one annotated GFA")
+    lines = gfa_lines(outputs[0])
+    nodes = gfa_telomere_nodes(lines)
+    require(len(nodes) == 2, f"selected path should create two telomere nodes, found {nodes}")
+    require(all("seg_fp" in node or "seg_lp" in node for node in nodes), "excluded path was annotated")
+    require(not any("seg_fn" in node or "seg_ln" in node for node in nodes), "excluded path was annotated")
+    assert_original_gfa_records_preserved(PATH_GFA, lines, {"H", "S", "L"})
+    require(
+        "P\tpath_nn\tseg_fn-,seg_ln-\t*" in lines,
+        "excluded path topology was changed",
+    )
+    require({line.split("\t")[1] for line in lines if line.startswith("P\t")} == {"path_pp", "path_nn"},
+            "an original GFA path disappeared")
+    assert_colors_match_nodes(out_dir, nodes)
+
+
+def _write(path, text):
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_gfa_pathless_filtering_and_preservation(tmp):
+    uppercase_gfa = tmp / "upper.GFA"
+    uppercase_gfa.write_bytes(PATHLESS_GFA.read_bytes())
+    out_dir = tmp / "gfa_pathless_out"
+    result = run_fasta(
+        uppercase_gfa,
+        out_dir,
+        ["--include-prefix", "seg_t2t", "-x", "0", "-l", "60"],
+    )
+    require_success(result, "pathless GFA filter")
+    require("selected 1 of 4 segments" in decode(result.stderr), "pathless GFA count is wrong")
+
+    outputs = sorted(out_dir.glob("*.telo.annotated.gfa"))
+    require(len(outputs) == 1, "expected one pathless annotated GFA")
+    lines = gfa_lines(outputs[0])
+    nodes = gfa_telomere_nodes(lines)
+    require(len(nodes) == 2, f"selected pathless segment should create two telomere nodes, found {nodes}")
+    require(all("seg_t2t" in node for node in nodes), "an excluded pathless segment was annotated")
+    for excluded in ("seg_p", "seg_q", "seg_none"):
+        require(not any(f"telomere_{excluded}" in line for line in lines), f"{excluded} was annotated")
+    assert_original_gfa_records_preserved(PATHLESS_GFA, lines, {"H", "S", "L"})
+    assert_colors_match_nodes(out_dir, nodes)
+
+
+def test_gfa_shared_terminal_selection_is_orientation_specific(tmp):
+    expected_by_path = {
+        "path_plus": {
+            "telomere_seg_shared+_start",
+            "telomere_seg_shared+_end",
+        },
+        "path_minus": {
+            "telomere_seg_shared-_start",
+            "telomere_seg_shared-_end",
+        },
+    }
+    observed_by_path = {}
+    for selected_path, expected_nodes in expected_by_path.items():
+        out_dir = tmp / f"shared_out_{selected_path}"
+        result = run_fasta(
+            SHARED_GFA,
+            out_dir,
+            ["--include-prefix", selected_path, "-x", "0", "-l", "60", "-j", "8"],
+        )
+        require_success(result, "shared-terminal GFA filter")
+        require("selected 1 of 2 paths" in decode(result.stderr), "shared-terminal GFA count is wrong")
+        outputs = sorted(out_dir.glob("*.telo.annotated.gfa"))
+        require(len(outputs) == 1, "expected one shared-terminal annotated GFA")
+        lines = gfa_lines(outputs[0])
+        nodes = gfa_telomere_nodes(lines)
+        require(nodes == expected_nodes, f"wrong shared-terminal annotations: {nodes}")
+        excluded_nodes = set().union(*expected_by_path.values()) - expected_nodes
+        require(not any(node in line for node in excluded_nodes for line in lines), "excluded orientation was annotated")
+        path_names = {line.split("\t")[1] for line in lines if line.startswith("P\t")}
+        require(path_names == {"path_plus", "path_minus"}, "shared-segment path was lost")
+        telomere_links = {
+            line for line in lines
+            if line.startswith("L\t") and any(node in line.split("\t") for node in nodes)
+        }
+        require(len(telomere_links) == 2, f"expected two shared-terminal links, found {telomere_links}")
+        assert_colors_match_nodes(out_dir, nodes)
+        observed_by_path[selected_path] = nodes
+    require(
+        observed_by_path["path_plus"].isdisjoint(observed_by_path["path_minus"]),
+        "selected and excluded shared-segment orientations produced the same annotations",
+    )
+
+
+def test_unsupported_gfa_records_are_rejected(tmp):
+    cases = {
+        "gfa2": (
+            "fixture.gfa2",
+            "H\tVN:Z:2.0\nS\tsegA\t12\tTTAGGGTTAGGG\nO\tpathA\tsegA+\n",
+            "do not support GFA2",
+        ),
+        "gfa2_header": (
+            "header_disguised.gfa",
+            "H\tVN:Z:2.0\nS\tsegA\t12\tTTAGGGTTAGGG\nO\tpathA\tsegA+\n",
+            "do not support GFA2 at line",
+        ),
+        "gfa2_o_record": (
+            "o_record.gfa",
+            "H\tVN:Z:1.0\nS\tsegA\tTTAGGGTTAGGG\nO\tpathA\tsegA+\n",
+            "do not support GFA2 record type 'O'",
+        ),
+        "walk": (
+            "walk.gfa",
+            "H\tVN:Z:1.1\nS\tsegA\tTTAGGGTTAGGG\nW\tsample\t0\tchr1\t0\t12\t>segA\n",
+            "do not support GFA1 W walks",
+        ),
+        "containment": (
+            "containment.gfa",
+            "H\tVN:Z:1.0\nS\tsegA\tTTAGGGTTAGGG\nS\tsegB\tTTAGGG\nC\tsegA\t+\tsegB\t+\t0\t6M\n",
+            "do not support GFA1 C containment",
+        ),
+        "unknown": (
+            "unknown.gfa",
+            "H\tVN:Z:1.0\nS\tsegA\tTTAGGGTTAGGG\nZ\tunsupported\n",
+            "do not support GFA record type 'Z'",
+        ),
+    }
+    for name, (filename, contents, diagnostic) in cases.items():
+        fixture = _write(tmp / filename, contents)
+        out_dir = tmp / f"{name}_out"
+        result = run_fasta(fixture, out_dir, ["--include-prefix", "seg"])
+        require_failure(result, f"unsupported {name} GFA", diagnostic)
+        require(not list(out_dir.glob("*.telo.annotated.gfa")), f"unsupported {name} GFA was written")
+        require(not list(out_dir.glob("*.telo.annotated.colors.csv")), f"unsupported {name} colors were written")
+
+
+def test_fasta_in_gfa_named_directory_is_not_misclassified(tmp):
+    misleading_dir = tmp / "inputs.gfa.archive"
+    misleading_dir.mkdir()
+    fasta = misleading_dir / "assembly.fa"
+    fasta.write_bytes(MULTI_FASTA.read_bytes())
+    out_dir = tmp / "misleading_directory_out"
+    result = run_fasta(fasta, out_dir, ["--include-prefix", "contig_t2t"])
+    assert_fasta_selection(result, out_dir, ["contig_t2t"], 3)
+    require(not list(out_dir.glob("*.telo.annotated.gfa")), "FASTA path was misclassified as GFA")
+
+
+def test_cli_surface_and_read_subset_guards(tmp):
+    help_result = run(["--help"])
+    require_success(help_result, "--help")
+    help_text = decode(help_result.stdout)
+    for option in ("--include-bed", "--exclude-bed", "--include-prefix", "--exclude-prefix"):
+        require(option in help_text, f"{option} is absent from --help")
+
+    version_result = run(["--version"])
+    require_success(version_result, "--version")
+    require("Teloscope v0.1.5" in decode(version_result.stdout), "binary version changed before release")
+
+    for mode in ("--fastq-subset", "--bam-subset"):
+        result = run([mode, "--include-prefix", "contig"], stdin=b"")
+        require_failure(result, f"{mode} filter guard", "cannot be used in read subset mode")
+
+    assembly_fastq = tmp / "assembly_mode.fastq"
+    assembly_fastq.write_text(
+        "@read1\nTTAGGGTTAGGG\n+\nIIIIIIIIIIII\n",
+        encoding="utf-8",
+    )
+    fastq_out = tmp / "assembly_fastq_out"
+    assembly_fastq_result = run_fasta(
+        assembly_fastq,
+        fastq_out,
+        ["--include-prefix", "read"],
+    )
+    require_failure(
+        assembly_fastq_result,
+        "filtered FASTQ in assembly mode",
+        "require FASTA input or a recognized GFA file",
+    )
+    require(not list(fastq_out.glob("*_report.tsv")), "filtered assembly-mode FASTQ produced a report")
+
+    for option in ("--include-bed", "--exclude-bed", "--include-prefix", "--exclude-prefix"):
+        missing_argument = run(["-f", MULTI_FASTA, option])
+        require_failure(
+            missing_argument,
+            f"missing {option} argument",
+            f"Option {option} is missing a required argument",
+        )
+
+
+TESTS = (
+    test_exact_id_and_all_text_outputs,
+    test_bed3_comments_directives_crlf_and_duplicates,
+    test_include_union_repetition_and_exclusion_precedence,
+    test_prefixes_are_trimmed_literal_and_case_sensitive,
+    test_fasta_primary_ids_with_crlf_and_tab_descriptions,
+    test_wrapped_gap_lf_crlf_parity,
+    test_plain_gzip_and_stdin_parity,
+    test_large_gzip_fasta_is_not_truncated_or_stalled,
+    test_selector_validation_failures,
+    test_gfa_path_filtering_and_preservation,
+    test_gfa_pathless_filtering_and_preservation,
+    test_gfa_shared_terminal_selection_is_orientation_specific,
+    test_unsupported_gfa_records_are_rejected,
+    test_fasta_in_gfa_named_directory_is_not_misclassified,
+    test_cli_surface_and_read_subset_guards,
+)
+
+
+def main():
+    require(TELOSCOPE.exists(), f"Teloscope binary not found: {TELOSCOPE}")
+    require(MULTI_FASTA.exists(), f"FASTA fixture not found: {MULTI_FASTA}")
+    require(SHARED_GFA.exists(), f"shared GFA fixture not found: {SHARED_GFA}")
+    require(LARGE_GZIP_FASTA.exists(), f"large gzip FASTA fixture not found: {LARGE_GZIP_FASTA}")
+    with tempfile.TemporaryDirectory(prefix="teloscope_sequence_filters_") as temp:
+        temp_root = pathlib.Path(temp)
+        for test in TESTS:
+            case_dir = temp_root / test.__name__
+            case_dir.mkdir()
+            try:
+                test(case_dir)
+            except Exception as error:
+                raise AssertionError(f"{test.__name__}: {error}") from error
+    print(f"PASS sequence filter integration ({len(TESTS)} groups)")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"FAIL sequence filter integration: {error}", file=sys.stderr)
+        raise

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -5,10 +5,13 @@
 #include <stdlib.h>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <set>
 #include <tuple>
 #include <fstream>
 #include <stdexcept> // jack: std::runtime_error
+#include <cctype>
+#include <cstring>
 
 #include "log.h"
 #include "global.h"
@@ -145,6 +148,420 @@ void appendFastqRecord(std::string &out, const FastqRecord &record) {
     out += '\n';
 }
 
+[[noreturn]] void sequenceFilterError(const std::string &message) {
+    fprintf(stderr, "Error: %s\n", message.c_str());
+    threadPool.join();
+    exit(EXIT_FAILURE);
+}
+
+std::string trimFilterLine(const std::string &value) {
+    const size_t first = value.find_first_not_of(" \t\r\n");
+    if (first == std::string::npos) return "";
+    const size_t last = value.find_last_not_of(" \t\r\n");
+    return value.substr(first, last - first + 1);
+}
+
+std::string sequenceFilterId(const std::string &header) {
+    const size_t firstWhitespace = header.find_first_of(" \t\r\n\f\v");
+    return header.substr(0, firstWhitespace);
+}
+
+bool hasCaseInsensitiveSuffix(const std::string &value, const std::string &suffix) {
+    if (value.size() < suffix.size()) return false;
+    return std::equal(suffix.rbegin(), suffix.rend(), value.rbegin(),
+        [](unsigned char left, unsigned char right) {
+            return std::tolower(left) == std::tolower(right);
+        });
+}
+
+bool isGfaAssemblyPath(const std::string &path) {
+    return hasCaseInsensitiveSuffix(path, ".gfa") ||
+           hasCaseInsensitiveSuffix(path, ".gfa.gz") ||
+           hasCaseInsensitiveSuffix(path, ".gfa2") ||
+           hasCaseInsensitiveSuffix(path, ".gfa2.gz");
+}
+
+bool readGzipLine(gzFile input, std::vector<char> &buffer, std::string &line,
+                  const std::string &path) {
+    line.clear();
+    while (true) {
+        char *chunk = gzgets(input, buffer.data(), static_cast<int>(buffer.size()));
+        if (chunk == nullptr) {
+            if (gzeof(input)) return !line.empty();
+            int errorNumber = Z_OK;
+            const char *errorMessage = gzerror(input, &errorNumber);
+            sequenceFilterError("Could not read assembly input '" + path + "': " +
+                                (errorMessage ? errorMessage : "zlib error") + ".");
+        }
+        const size_t chunkLength = std::strlen(chunk);
+        line.append(chunk, chunkLength);
+        if (chunkLength > 0 && line.back() == '\n') {
+            line.pop_back();
+            return true;
+        }
+        if (gzeof(input)) return true;
+    }
+}
+
+void validateFilteredGfaInput(const UserInputTeloscope &input) {
+    if (hasCaseInsensitiveSuffix(input.inSequence, ".gfa2") ||
+        hasCaseInsensitiveSuffix(input.inSequence, ".gfa2.gz")) {
+        sequenceFilterError("Assembly record filters do not support GFA2; use GFA1 P paths or a pathless GFA1 graph.");
+    }
+
+    gzFile stream = gzopen(input.inSequence.c_str(), "rb");
+    if (stream == nullptr) {
+        sequenceFilterError("Could not open assembly input '" + input.inSequence + "'.");
+    }
+    gzbuffer(stream, 1U << 20);
+    std::vector<char> buffer(1U << 16);
+    std::string validationError;
+    uint64_t lineNumber = 0;
+    for (std::string line; readGzipLine(stream, buffer, line, input.inSequence); ) {
+        lineNumber++;
+        line.erase(std::remove(line.begin(), line.end(), '\r'), line.end());
+        if (line.empty() || line.front() == '#') continue;
+        if (line.rfind("H\t", 0) == 0 && line.find("\tVN:Z:2") != std::string::npos) {
+            validationError = "Assembly record filters do not support GFA2 at line " +
+                              std::to_string(lineNumber) +
+                              "; use GFA1 P paths or a pathless GFA1 graph.";
+            break;
+        }
+        if (line.size() < 2 || line[1] != '\t') {
+            validationError = "Assembly record filters found a malformed or unsupported GFA record at line " +
+                              std::to_string(lineNumber) + ".";
+            break;
+        }
+        const char recordType = line.front();
+        if (recordType == 'O' || recordType == 'U' || recordType == 'E' ||
+            recordType == 'G' || recordType == 'F') {
+            validationError = std::string("Assembly record filters do not support GFA2 record type '") +
+                              recordType + "' at line " + std::to_string(lineNumber) +
+                              "; use GFA1 P paths or a pathless GFA1 graph.";
+            break;
+        }
+        if (recordType == 'W') {
+            validationError = "Assembly record filters do not support GFA1 W walks at line " +
+                              std::to_string(lineNumber) +
+                              "; use GFA1 P paths or a pathless GFA1 graph.";
+            break;
+        }
+        if (recordType == 'C') {
+            validationError = "Assembly record filters do not support GFA1 C containment records at line " +
+                              std::to_string(lineNumber) + ".";
+            break;
+        }
+        if (recordType == 'S') {
+            const size_t secondTab = line.find('\t', 2);
+            const size_t thirdTab = secondTab == std::string::npos
+                ? std::string::npos : line.find('\t', secondTab + 1);
+            if (thirdTab != std::string::npos) {
+                const std::string lengthField = line.substr(secondTab + 1,
+                                                            thirdTab - secondTab - 1);
+                if (!lengthField.empty() &&
+                    std::all_of(lengthField.begin(), lengthField.end(),
+                                [](unsigned char c) { return std::isdigit(c); })) {
+                    validationError = "Assembly record filters do not support GFA2 segment records at line " +
+                                      std::to_string(lineNumber) +
+                                      "; use GFA1 P paths or a pathless GFA1 graph.";
+                    break;
+                }
+            }
+        }
+        if (recordType != 'H' && recordType != 'S' && recordType != 'L' &&
+            recordType != 'J' && recordType != 'P') {
+            validationError = std::string("Assembly record filters do not support GFA record type '") +
+                              recordType + "' at line " + std::to_string(lineNumber) + ".";
+            break;
+        }
+    }
+    const int closeResult = gzclose(stream);
+    if (closeResult != Z_OK) {
+        sequenceFilterError("Could not close assembly input '" + input.inSequence + "'.");
+    }
+    if (!validationError.empty()) sequenceFilterError(validationError);
+}
+
+void loadNormalizedFastaAssembly(UserInputTeloscope &input, InSequences &sequences) {
+    gzFile gzipInput = nullptr;
+    std::istream *plainInput = nullptr;
+    if (input.inSequence.empty()) {
+        plainInput = &std::cin;
+    } else {
+        gzipInput = gzopen(input.inSequence.c_str(), "rb");
+        if (gzipInput == nullptr) {
+            sequenceFilterError("Could not open assembly input '" + input.inSequence + "'.");
+        }
+        gzbuffer(gzipInput, 1U << 20);
+    }
+
+    std::vector<char> gzipBuffer(1U << 16);
+    auto readLine = [&](std::string &line) {
+        if (plainInput != nullptr) return static_cast<bool>(std::getline(*plainInput, line));
+        return readGzipLine(gzipInput, gzipBuffer, line, input.inSequence);
+    };
+
+    uint32_t sequencePosition = 0;
+    std::unordered_set<std::string> seenIds;
+    std::string primaryId;
+    std::string comment;
+    std::string *sequence = nullptr;
+    auto appendRecord = [&]() {
+        if (sequence == nullptr) return;
+        if (sequence->empty()) {
+            delete sequence;
+            sequenceFilterError("FASTA record '" + primaryId + "' has no sequence.");
+        }
+        Sequence *record = new Sequence{primaryId, comment, sequence, nullptr, sequencePosition++};
+        sequences.appendSequence(record, input.hc_cutoff);
+        sequence = nullptr;
+    };
+
+    bool firstLine = true;
+    for (std::string line; readLine(line); ) {
+        line.erase(std::remove(line.begin(), line.end(), '\r'), line.end());
+        if (firstLine && line.size() >= 3 &&
+            static_cast<unsigned char>(line[0]) == 0xef &&
+            static_cast<unsigned char>(line[1]) == 0xbb &&
+            static_cast<unsigned char>(line[2]) == 0xbf) {
+            line.erase(0, 3);
+        }
+        firstLine = false;
+
+        if (!line.empty() && line.front() == '>') {
+            appendRecord();
+            const std::string headerLine = line.substr(1);
+            primaryId = sequenceFilterId(headerLine);
+            if (primaryId.empty()) {
+                sequenceFilterError("FASTA input contains an empty primary sequence ID.");
+            }
+            if (!seenIds.insert(primaryId).second) {
+                sequenceFilterError("Input contains duplicate primary sequence ID: '" + primaryId + "'.");
+            }
+            const size_t firstWhitespace = headerLine.find_first_of(" \t\r\n\f\v");
+            comment = firstWhitespace == std::string::npos
+                ? "" : trimFilterLine(headerLine.substr(firstWhitespace + 1));
+            sequence = new std::string;
+        } else {
+            if (sequence == nullptr) {
+                sequenceFilterError("Assembly record filters require FASTA input or a recognized GFA file.");
+            }
+            sequence->append(line);
+        }
+    }
+
+    appendRecord();
+    if (sequencePosition == 0) sequenceFilterError("Assembly input is empty.");
+    if (gzipInput != nullptr && gzclose(gzipInput) != Z_OK) {
+        sequenceFilterError("Could not close assembly input '" + input.inSequence + "'.");
+    }
+
+    jobWait(threadPool);
+    sequences.updateStats();
+}
+
+bool parseUnsignedCoordinate(const std::string &value, uint64_t &coordinate) {
+    if (value.empty() ||
+        !std::all_of(value.begin(), value.end(), [](unsigned char c) { return std::isdigit(c); })) {
+        return false;
+    }
+    try {
+        size_t parsed = 0;
+        const unsigned long long result = std::stoull(value, &parsed);
+        if (parsed != value.size()) return false;
+        coordinate = static_cast<uint64_t>(result);
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+struct SequenceSelection {
+    std::unordered_set<std::string> names;
+    uint64_t selectedCount = 0;
+};
+
+class SequenceSelector {
+    std::unordered_set<std::string> includeIds;
+    std::unordered_set<std::string> excludeIds;
+    std::vector<std::string> includePrefixes;
+    std::vector<std::string> excludePrefixes;
+    bool active = false;
+
+    static bool startsWith(const std::string &value, const std::string &prefix) {
+        return value.size() >= prefix.size() &&
+               value.compare(0, prefix.size(), prefix) == 0;
+    }
+
+    static void deduplicatePrefixes(std::vector<std::string> &prefixes) {
+        std::unordered_set<std::string> seen;
+        std::vector<std::string> unique;
+        unique.reserve(prefixes.size());
+        for (const std::string &prefix : prefixes) {
+            if (seen.insert(prefix).second) unique.push_back(prefix);
+        }
+        prefixes.swap(unique);
+    }
+
+    static void loadSelectorFiles(const std::vector<std::string> &files,
+                                  std::unordered_set<std::string> &ids,
+                                  const char *optionName) {
+        for (const std::string &path : files) {
+            std::ifstream input(path);
+            if (!input.is_open()) {
+                sequenceFilterError(std::string("Could not open ") + optionName + " file '" + path + "'.");
+            }
+
+            uint64_t idLines = 0;
+            uint64_t lineNumber = 0;
+            for (std::string raw; std::getline(input, raw); ) {
+                lineNumber++;
+                if (lineNumber == 1 && raw.size() >= 3 &&
+                    static_cast<unsigned char>(raw[0]) == 0xef &&
+                    static_cast<unsigned char>(raw[1]) == 0xbb &&
+                    static_cast<unsigned char>(raw[2]) == 0xbf) {
+                    raw.erase(0, 3);
+                }
+                const std::string line = trimFilterLine(raw);
+                if (line.empty() || line.front() == '#') continue;
+
+                std::istringstream fieldsStream(line);
+                std::vector<std::string> fields;
+                for (std::string field; fieldsStream >> field; ) fields.push_back(field);
+                if (fields.empty()) continue;
+                if (fields[0] == "track" || fields[0] == "browser") continue;
+                if (fields.size() == 2) {
+                    sequenceFilterError(path + ":" + std::to_string(lineNumber) +
+                                        " must contain either one ID column or at least three BED columns.");
+                }
+                if (fields.size() >= 3) {
+                    uint64_t begin = 0, end = 0;
+                    if (!parseUnsignedCoordinate(fields[1], begin) ||
+                        !parseUnsignedCoordinate(fields[2], end) || begin > end) {
+                        sequenceFilterError(path + ":" + std::to_string(lineNumber) +
+                                            " has invalid BED start/end coordinates.");
+                    }
+                }
+
+                ids.insert(fields[0]);
+                idLines++;
+            }
+
+            if (idLines == 0) {
+                sequenceFilterError(std::string(optionName) + " file '" + path +
+                                    "' contains no sequence IDs.");
+            }
+        }
+    }
+
+    static bool matchesAnyPrefix(const std::string &name,
+                                 const std::vector<std::string> &prefixes) {
+        return std::any_of(prefixes.begin(), prefixes.end(),
+                           [&](const std::string &prefix) { return startsWith(name, prefix); });
+    }
+
+    static std::string describeUnmatched(const std::vector<std::string> &values) {
+        constexpr size_t displayLimit = 10;
+        std::ostringstream message;
+        const size_t shown = std::min(values.size(), displayLimit);
+        for (size_t i = 0; i < shown; ++i) {
+            if (i > 0) message << ", ";
+            message << "'" << values[i] << "'";
+        }
+        if (values.size() > shown) message << " (and " << (values.size() - shown) << " more)";
+        return message.str();
+    }
+
+    void validateSelectors(const std::vector<std::string> &names,
+                           const std::string &domainLabel) const {
+        const std::unordered_set<std::string> available(names.begin(), names.end());
+        std::vector<std::string> unmatchedIds;
+        std::vector<std::string> unmatchedPrefixes;
+
+        for (const std::string &id : includeIds)
+            if (available.count(id) == 0) unmatchedIds.push_back(id);
+        for (const std::string &id : excludeIds)
+            if (available.count(id) == 0) unmatchedIds.push_back(id);
+
+        auto validatePrefixList = [&](const std::vector<std::string> &prefixes) {
+            for (const std::string &prefix : prefixes) {
+                const bool matched = std::any_of(names.begin(), names.end(),
+                    [&](const std::string &name) { return startsWith(name, prefix); });
+                if (!matched) unmatchedPrefixes.push_back(prefix);
+            }
+        };
+        validatePrefixList(includePrefixes);
+        validatePrefixList(excludePrefixes);
+
+        if (!unmatchedIds.empty()) {
+            std::sort(unmatchedIds.begin(), unmatchedIds.end());
+            unmatchedIds.erase(std::unique(unmatchedIds.begin(), unmatchedIds.end()),
+                               unmatchedIds.end());
+            sequenceFilterError("Sequence filter ID(s) matched no input " + domainLabel + ": " +
+                                describeUnmatched(unmatchedIds) + ".");
+        }
+        if (!unmatchedPrefixes.empty()) {
+            std::sort(unmatchedPrefixes.begin(), unmatchedPrefixes.end());
+            unmatchedPrefixes.erase(std::unique(unmatchedPrefixes.begin(), unmatchedPrefixes.end()),
+                                    unmatchedPrefixes.end());
+            sequenceFilterError("Sequence filter prefix(es) matched no input " + domainLabel + ": " +
+                                describeUnmatched(unmatchedPrefixes) + ".");
+        }
+    }
+
+public:
+    explicit SequenceSelector(const UserInputTeloscope &input)
+        : includePrefixes(input.includePrefixes), excludePrefixes(input.excludePrefixes),
+          active(input.sequenceFilterActive) {
+        loadSelectorFiles(input.includeBedFiles, includeIds, "--include-bed");
+        loadSelectorFiles(input.excludeBedFiles, excludeIds, "--exclude-bed");
+        deduplicatePrefixes(includePrefixes);
+        deduplicatePrefixes(excludePrefixes);
+    }
+
+    SequenceSelection select(const std::vector<std::string> &candidateNames,
+                             const std::string &domainLabel) const {
+        SequenceSelection selection;
+        selection.names.reserve(candidateNames.size());
+
+        if (active) {
+            std::unordered_set<std::string> uniqueNames;
+            std::vector<std::string> duplicateNames;
+            for (const std::string &name : candidateNames) {
+                if (name.empty()) {
+                    sequenceFilterError("Input contains an empty primary sequence ID.");
+                }
+                if (!uniqueNames.insert(name).second) duplicateNames.push_back(name);
+            }
+            if (!duplicateNames.empty()) {
+                std::sort(duplicateNames.begin(), duplicateNames.end());
+                duplicateNames.erase(std::unique(duplicateNames.begin(), duplicateNames.end()),
+                                     duplicateNames.end());
+                sequenceFilterError("Input contains duplicate primary sequence ID(s): " +
+                                    describeUnmatched(duplicateNames) + ".");
+            }
+            validateSelectors(candidateNames, domainLabel);
+        }
+
+        const bool hasIncludes = !includeIds.empty() || !includePrefixes.empty();
+        for (const std::string &name : candidateNames) {
+            const bool included = !hasIncludes || includeIds.count(name) != 0 ||
+                                  matchesAnyPrefix(name, includePrefixes);
+            const bool excluded = excludeIds.count(name) != 0 ||
+                                  matchesAnyPrefix(name, excludePrefixes);
+            if (included && !excluded) {
+                selection.names.insert(name);
+                selection.selectedCount++;
+            }
+        }
+
+        if (active && selection.selectedCount == 0) {
+            sequenceFilterError("Sequence filters excluded all input " + domainLabel + ".");
+        }
+        return selection;
+    }
+};
+
 } // namespace
 
 
@@ -156,16 +573,56 @@ void Input::load(UserInputTeloscope userInput) {
 
 
 void Input::read(InSequences &inSequences) {
-    loadGenome(userInput, inSequences);
+    SequenceSelector selector(userInput);
+    const bool isGfa = isGfaAssemblyPath(userInput.inSequence);
+    if (isGfa && userInput.sequenceFilterActive) validateFilteredGfaInput(userInput);
+    if (isGfa || !userInput.sequenceFilterActive) {
+        loadGenome(userInput, inSequences);
+    } else {
+        loadNormalizedFastaAssembly(userInput, inSequences);
+    }
     lg.verbose("Finished loading genome assembly");
 
-    std::vector<InPath> inPaths = inSequences.getInPaths();
     std::vector<InSegment*> *inSegments = inSequences.getInSegments();
     std::vector<InGap> *inGaps = inSequences.getInGaps();
+
+    std::vector<InPath> inPaths = inSequences.getInPaths();
+    if (!isGfa && userInput.sequenceFilterActive) {
+        // Normalize FASTA primary IDs at the first ASCII whitespace character.
+        for (InPath &path : inPaths) path.setHeader(sequenceFilterId(path.getHeader()));
+    }
+
+    const bool filterSegments = isGfa && inPaths.empty();
+    std::vector<std::string> candidateNames;
+    if (filterSegments) {
+        candidateNames.reserve(inSegments->size());
+        for (InSegment *segment : *inSegments)
+            candidateNames.push_back(sequenceFilterId(segment->getSeqHeader()));
+    } else {
+        candidateNames.reserve(inPaths.size());
+        for (InPath &path : inPaths)
+            candidateNames.push_back(sequenceFilterId(path.getHeader()));
+    }
+
+    const std::string domainLabel = filterSegments ? "segments" : "paths";
+    const SequenceSelection selection = selector.select(candidateNames, domainLabel);
+    if (userInput.sequenceFilterActive) {
+        userInput.filterInputCount = candidateNames.size();
+        userInput.filterSelectedCount = selection.selectedCount;
+        fprintf(stderr, "Sequence filter: selected %" PRIu64 " of %" PRIu64 " %s.\n",
+                userInput.filterSelectedCount, userInput.filterInputCount, domainLabel.c_str());
+    }
+    if (!filterSegments) {
+        inPaths.erase(std::remove_if(inPaths.begin(), inPaths.end(),
+            [&](InPath &path) {
+                return selection.names.count(sequenceFilterId(path.getHeader())) == 0;
+            }), inPaths.end());
+    }
+
     Teloscope teloscope(userInput);
 
     // GFA-based annotation
-    if (userInput.inSequence.find(".gfa") != std::string::npos) {
+    if (isGfa) {
 
         // One scan job per terminal end. Resolve every job before queuing any:
         // worker threads append telomere nodes to the live segment vector, so
@@ -201,8 +658,10 @@ void Input::read(InSequences &inSequences) {
                                 std::get<1>(end), std::get<2>(end), true});
         } else {
             // Fallback: path-less GFA, scan all segments (implicit + orientation)
-            for (InSegment* inSegment : *inSegments)
-                jobs.push_back({inSegment, '+', false, false});
+            for (InSegment* inSegment : *inSegments) {
+                if (selection.names.count(sequenceFilterId(inSegment->getSeqHeader())) != 0)
+                    jobs.push_back({inSegment, '+', false, false});
+            }
         }
 
         // Count missing sequence now, while the segment vector is still stable.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -100,9 +100,59 @@ int main(int argc, char **argv) {
             userInput.outRoute = userInput.inSequencePrefix;
     };
 
+    auto addBedFilterFile = [&](const char* path, std::vector<std::string>& files,
+                                const char* optionName) {
+        const std::filesystem::path selectorPath(path ? path : "");
+        std::error_code error;
+        if (selectorPath.empty() || !std::filesystem::exists(selectorPath, error) || error) {
+            fprintf(stderr, "Error: %s file does not exist: '%s'.\n", optionName,
+                    path ? path : "");
+            exit(EXIT_FAILURE);
+        }
+        if (!std::filesystem::is_regular_file(selectorPath, error) || error) {
+            fprintf(stderr, "Error: %s file '%s' is not a regular file.\n", optionName, path);
+            exit(EXIT_FAILURE);
+        }
+        const std::filesystem::path resolved = std::filesystem::canonical(selectorPath, error);
+        if (error) {
+            fprintf(stderr, "Error: Could not resolve %s file '%s': %s.\n", optionName,
+                    path, error.message().c_str());
+            exit(EXIT_FAILURE);
+        }
+        files.push_back(resolved.string());
+        userInput.sequenceFilterActive = true;
+    };
+
+    auto addPrefixFilters = [&](const char* value, std::vector<std::string>& prefixes,
+                                const char* optionName) {
+        std::istringstream stream(value ? value : "");
+        std::string prefix;
+        bool found = false;
+        while (std::getline(stream, prefix, ',')) {
+            const size_t first = prefix.find_first_not_of(" \t\r\n");
+            const size_t last = prefix.find_last_not_of(" \t\r\n");
+            if (first == std::string::npos) {
+                fprintf(stderr, "Error: %s contains an empty prefix.\n", optionName);
+                exit(EXIT_FAILURE);
+            }
+            prefix = prefix.substr(first, last - first + 1);
+            prefixes.push_back(prefix);
+            found = true;
+        }
+        if (!found || (value && value[0] != '\0' && value[strlen(value) - 1] == ',')) {
+            fprintf(stderr, "Error: %s contains an empty prefix.\n", optionName);
+            exit(EXIT_FAILURE);
+        }
+        userInput.sequenceFilterActive = true;
+    };
+
     static struct option long_options[] = { // struct mapping long options
         {"input-sequence", required_argument, 0, 'f'},
         {"output", required_argument, 0, 'o'},
+        {"include-bed", required_argument, 0, 0},
+        {"exclude-bed", required_argument, 0, 0},
+        {"include-prefix", required_argument, 0, 0},
+        {"exclude-prefix", required_argument, 0, 0},
         {"patterns", required_argument, 0, 'p'},
         {"window", required_argument, 0, 'w'},
         {"step", required_argument, 0, 's'},
@@ -145,15 +195,14 @@ int main(int argc, char **argv) {
         }
         switch (c) {
             case ':': // handle options without arguments
-                switch (optopt) { // the command line option last matched
-                    // case 'b':
-                    //     break;
-                        
-                    default:
-                        fprintf(stderr, "Error: Option -%c is missing a required argument\n", optopt);
-                        return EXIT_FAILURE;
+                if (optopt == 0 && optind > 0 && optind <= argc &&
+                    strncmp(argv[optind - 1], "--", 2) == 0) {
+                    fprintf(stderr, "Error: Option %s is missing a required argument\n",
+                            argv[optind - 1]);
+                } else {
+                    fprintf(stderr, "Error: Option -%c is missing a required argument\n", optopt);
                 }
-                break;
+                return EXIT_FAILURE;
             default: // handle positional arguments
 
 
@@ -164,6 +213,14 @@ int main(int argc, char **argv) {
                     userInput.fastqSubset = true;
                 else if (strcmp(long_options[option_index].name, "bam-subset") == 0)
                     userInput.bamSubset = true;
+                else if (strcmp(long_options[option_index].name, "include-bed") == 0)
+                    addBedFilterFile(optarg, userInput.includeBedFiles, "--include-bed");
+                else if (strcmp(long_options[option_index].name, "exclude-bed") == 0)
+                    addBedFilterFile(optarg, userInput.excludeBedFiles, "--exclude-bed");
+                else if (strcmp(long_options[option_index].name, "include-prefix") == 0)
+                    addPrefixFilters(optarg, userInput.includePrefixes, "--include-prefix");
+                else if (strcmp(long_options[option_index].name, "exclude-prefix") == 0)
+                    addPrefixFilters(optarg, userInput.excludePrefixes, "--exclude-prefix");
                 break;
 
 
@@ -483,6 +540,11 @@ int main(int argc, char **argv) {
                 printf("\nOptional Parameters:\n");
                 printf("\t'-w'\t--window\tSet sliding window size. [Default: 1000]\n");
                 printf("\t'-s'\t--step\tSet sliding window step. [Default: 1000 (non-overlapping)]\n");
+                printf("\t\t--include-bed FILE\tAnalyze whole records whose IDs occur in BED/list column 1. Repeatable. [Default: unset]\n");
+                printf("\t\t--exclude-bed FILE\tExclude whole records whose IDs occur in BED/list column 1. Repeatable. [Default: unset]\n");
+                printf("\t\t--include-prefix LIST\tAnalyze IDs with a literal, comma-separated prefix. Repeatable. [Default: unset]\n");
+                printf("\t\t--exclude-prefix LIST\tExclude IDs with a literal, comma-separated prefix. Repeatable. [Default: unset]\n");
+                printf("\t\tRecord filters are off by default. Matching is case-sensitive; includes form a union and exclusions apply last. FASTA uses the first ID token; BED never crops records.\n");
                 printf("\t'-r'\t--out-win-repeats\tOutput per-window repeat density, canonical ratio, and strand ratio. [Default: false]\n");
                 printf("\t'-g'\t--out-gc\tOutput GC content for each window. [Default: false]\n");
                 printf("\t'-e'\t--out-entropy\tOutput Shannon entropy for each window. [Default: false]\n");
@@ -528,6 +590,12 @@ int main(int argc, char **argv) {
 
     if (userInput.fastqSubset && userInput.bamSubset) {
         fprintf(stderr, "Error: --fastq-subset and --bam-subset are mutually exclusive.\n");
+        exit(EXIT_FAILURE);
+    }
+
+    if (userInput.sequenceFilterActive && (userInput.fastqSubset || userInput.bamSubset)) {
+        fprintf(stderr, "Error: --include-bed/--exclude-bed/--include-prefix/--exclude-prefix "
+                        "filter assembly records and cannot be used in read subset mode.\n");
         exit(EXIT_FAILURE);
     }
 

--- a/src/teloscope.cpp
+++ b/src/teloscope.cpp
@@ -1006,6 +1006,10 @@ void Teloscope::printSummary(std::ofstream& reportFile) {
 
     out("\n+++ Assembly Summary Report +++\n");
     out("Total paths:\t", totalPaths, "\n");
+    if (userInput.sequenceFilterActive) {
+        out("Filter input paths:\t", userInput.filterInputCount, "\n");
+        out("Filter selected paths:\t", userInput.filterSelectedCount, "\n");
+    }
     out("Total gaps:\t", totalGaps, "\n");
     out("Scaffold N50:\t", scaffoldN50, "\n");
     out("Contig N50:\t", contigN50, "\n");


### PR DESCRIPTION
## Summary
- Add BED-based whole-record inclusion and exclusion filters.
- Add repeatable comma-separated prefix inclusion and exclusion filters.
- Apply include selectors as a union and exclusions last.
- Reject unsafe filtered input modes and unsupported GFA records.
- Document defaults, accession nomenclature, behavior, and limitations.

## Validation
- make all -j4
- make test-filters: 15 groups passed
- ASan and UBSan filter suite: 15 groups passed
- build/bin/teloscope-validate validateFiles
- make test-gaps: 12 of 12 passed
- make test-n50
- BAM integration tests
- report tests: 10 passed
- filtered plot-report PDF smoke test