### PR TITLE
Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,15 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+version: 2
+
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.12"
+
+mkdocs:
+  configuration: mkdocs.yml
+
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ results/
 | [Testing](docs/testing.md) | validator runs, report regression checks, and test regeneration |
 | [Troubleshooting](docs/troubleshooting.md) | common build, input, and runtime failures |
 | [Release checklist](docs/release.md) | GitHub, Bioconda, and Zenodo release steps |
-| [Validation format](validateFiles/README.md) | the `.tst` harness, including directive-mode GFA cases |
+| [Validation format](https://github.com/vgl-hub/teloscope/blob/main/validateFiles/README.md) | the `.tst` harness, including directive-mode GFA cases |
 
 ## Repo layout
 

--- a/docs/algorithm.md
+++ b/docs/algorithm.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md)
+[Back to README](index.md)
 
 # Teloscope algorithm
 

--- a/docs/classification.md
+++ b/docs/classification.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md)
+[Back to README](index.md)
 
 # Chromosome classification
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,9 @@
+<!--
+This page reuses the repository README as the documentation home so there is a
+single source of truth. The include-markdown plugin pulls in ../README.md at
+build time and rewrites its relative links to work inside the docs site.
+-->
+{%
+   include-markdown "../README.md"
+   rewrite-relative-urls=true
+%}

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md)
+[Back to README](index.md)
 
 # Outputs
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md)
+[Back to README](index.md)
 
 # Parameters
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md)
+[Back to README](index.md)
 
 # Release checklist
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md)
+[Back to README](index.md)
 
 # Report generation
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+# Documentation build dependencies (Read the Docs / local `mkdocs serve`)
+mkdocs-material>=9.5
+mkdocs-include-markdown-plugin>=6.2

--- a/docs/simulation.md
+++ b/docs/simulation.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md)
+[Back to README](index.md)
 
 # Simulation and validation
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md)
+[Back to README](index.md)
 
 # Testing
 
@@ -58,7 +58,7 @@ gfa_expect testFiles/expected/gfa/gfa_pathless_small.tsv
 gfa_preserve_input strict
 ```
 
-`%OUTDIR%` is replaced by a per-test temporary directory. GFA expectations are semantic, not raw file diffs. See [validateFiles/README.md](../validateFiles/README.md) for the full format.
+`%OUTDIR%` is replaced by a per-test temporary directory. GFA expectations are semantic, not raw file diffs. See [validateFiles/README.md](https://github.com/vgl-hub/teloscope/blob/main/validateFiles/README.md) for the full format.
 
 ## Regenerate legacy expected outputs
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,4 +1,4 @@
-[Back to README](../README.md)
+[Back to README](index.md)
 
 # Troubleshooting
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,69 @@
+site_name: Teloscope
+site_description: Scan assembly ends for telomeric repeats — FASTA, FASTA.gz, and GFA aware.
+site_url: https://teloscope.readthedocs.io/
+repo_url: https://github.com/vgl-hub/teloscope
+repo_name: vgl-hub/teloscope
+edit_uri: edit/main/docs/
+copyright: Part of the gfastar tool suite.
+
+docs_dir: docs
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.top
+    - navigation.footer
+    - toc.follow
+    - content.code.copy
+    - search.suggest
+    - search.highlight
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: green
+      accent: green
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: green
+      accent: green
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+
+plugins:
+  - search
+  - include-markdown
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
+
+nav:
+  - Home: index.md
+  - Parameters: parameters.md
+  - Outputs: outputs.md
+  - Classification: classification.md
+  - Algorithm: algorithm.md
+  - Report generation: report.md
+  - Simulation: simulation.md
+  - Testing: testing.md
+  - Troubleshooting: troubleshooting.md
+  - Release checklist: release.md
+  - Validation format: https://github.com/vgl-hub/teloscope/blob/main/validateFiles/README.md


### PR DESCRIPTION
This pull request sets up documentation building and hosting with MkDocs and Read the Docs, and improves the maintainability and usability of the documentation. The main changes include adding configuration files for Read the Docs and MkDocs, updating documentation dependencies, and refactoring internal links for better compatibility with the documentation site.

**Documentation build and hosting setup:**

* Added `.readthedocs.yaml` to configure Read the Docs builds, specifying the OS, Python version, and requirements file for building the docs (`.readthedocs.yaml`).
* Added `mkdocs.yml` to configure the MkDocs documentation site, including theme, navigation, plugins, and repository links (`mkdocs.yml`).
* Added `docs/requirements.txt` to specify documentation build dependencies (`mkdocs-material`, `mkdocs-include-markdown-plugin`) (`docs/requirements.txt`).

**Documentation content improvements:**

* Created `docs/index.md` to reuse the repository `README.md` as the documentation homepage, ensuring a single source of truth (`docs/index.md`).
* Updated all documentation files to use `[Back to README](index.md)` for internal navigation instead of relative paths, improving compatibility with the MkDocs site (multiple files). [[1]](diffhunk://#diff-e61eba1582eeedfd4ff570ff3aac50145ea32650c398cf9fbd19678071e4566cL1-R1) [[2]](diffhunk://#diff-a63d2047d2628a6ef108fe6cf46b952502b2fa3f62c459af482a3744e70cf981L1-R1) [[3]](diffhunk://#diff-3b979db8fe1a091621af10f24bf1c82d8640ceecb8a784a9bcb16d2a111b0db7L1-R1) [[4]](diffhunk://#diff-7ad93860b53d91cc603737c90612d6533ce53edf882eda504ddd476df97c9a2fL1-R1) [[5]](diffhunk://#diff-87479ac9ea16cec5ceafce00b3b049d7d5920cb663afae42901f20e7c4e6705dL1-R1) [[6]](diffhunk://#diff-296b0f19b5d8d2c71eb616afb9cf18129e1f67b7a61c89d303bf7e80558825fcL1-R1) [[7]](diffhunk://#diff-e3501cd20d40eb121af21a267e97e556d196388980cca1559af350fa957c131cL1-R1) [[8]](diffhunk://#diff-c22885d97fa21ad974a3f5f982d92b6f45edc251fd34bc14223492ebd7391245L1-R1) [[9]](diffhunk://#diff-373ebedf1806538a48b09135d964fe714cd54bd8c385e2ef97383324b759e82dL1-R1)

**Link and navigation fixes:**

* Updated links to the validation format documentation in `README.md` and `docs/testing.md` to point to the GitHub location, ensuring they work from both the docs site and repository (`README.md`, `docs/testing.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L120-R120) [[2]](diffhunk://#diff-c22885d97fa21ad974a3f5f982d92b6f45edc251fd34bc14223492ebd7391245L61-R61)