### PR TITLE
Cite the published Cell paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Teloscope
 [<img alt="github" src="https://img.shields.io/badge/github-vgl--hub/teloscope-8da0cb?style=for-the-badge&labelColor=555555&logo=github" height="20">](https://github.com/vgl-hub/teloscope)
 [<img alt="bioconda" src="https://img.shields.io/badge/bioconda-teloscope-44A833?style=for-the-badge&labelColor=555555&logo=Anaconda" height="20">](https://bioconda.github.io/recipes/teloscope/README.html)
-[![DOI](https://zenodo.org/badge/DOI/10.1101/2025.10.14.682431.svg)](https://doi.org/10.1101/2025.10.14.682431)
+[![DOI](https://zenodo.org/badge/DOI/10.1016/j.cell.2026.07.018.svg)](https://doi.org/10.1016/j.cell.2026.07.018)
 [![Anaconda-Server Badge](https://anaconda.org/bioconda/teloscope/badges/version.svg)](https://anaconda.org/bioconda/teloscope)
 [![Anaconda-Server Badge](https://anaconda.org/bioconda/teloscope/badges/platforms.svg)](https://anaconda.org/bioconda/teloscope)
 [![Anaconda-Server Badge](https://anaconda.org/bioconda/teloscope/badges/license.svg)](https://anaconda.org/bioconda/teloscope)
@@ -174,5 +174,5 @@ If you use Teloscope, cite:
 
 The complete genome of a songbird  
 Giulio Formenti, Nivesh Jain, Jack A. Medico, Marco Sollitto, Dmitry Antipov, Suziane Barcellos, Matthew Biegler, Ines Borges, J King Chang, Ying Chen, Haoyu Cheng, Helena Conceicao, Matthew Davenport, Lorraine De Oliveira, Erick Duarte, Gillian Durham, Jonathan Fenn, Niamh Forde, Pedro A. Galante, Kenji Gerhardt, Alice M. Giani, Simona Giunta, Juhyun Kim, Aleksey Komissarov, Bonhwang Koo, Sergey Koren, Denis Larkin, Chul Lee, Heng Li, Kateryna Makova, Patrick Masterson, Terence Murphy, Kirsty McCaffrey, Rafael L.V. Mercuri, Yeojung Na, Mary J. O'Connell, Shujun Ou, Adam Phillippy, Marina Popova, Arang Rhie, Francisco J. Ruiz-Ruano, Simona Secomandi, Linnea Smeds, Alexander Suh, Tatiana Tilley, Niki Vontzou, Paul D. Waters, Jennifer Balacco, Erich D. Jarvis  
-bioRxiv 2025.10.14.682431  
-https://doi.org/10.1101/2025.10.14.682431
+Cell, Volume 189, Issue 16, pages 4922-4945.e12, August 06, 2026  
+https://doi.org/10.1016/j.cell.2026.07.018


### PR DESCRIPTION
The songbird genome paper is out, so the README now points at the journal version instead of the preprint.

- DOI badge moves from `10.1101/2025.10.14.682431` to `10.1016/j.cell.2026.07.018`
- Citation block gives the Cell volume, issue, pages and date

Title and author list were already correct and are untouched. `docs/index.md` pulls README.md in at build time, so it picks this up automatically.