### PR TITLE
Correct stale block labelling docs

### DIFF
--- a/docs/algorithm.md
+++ b/docs/algorithm.md
@@ -17,7 +17,7 @@ Teloscope has two input modes:
 4. Build a multi-pattern search structure and scan each sequence.
 5. Merge nearby matches into repeat groups, then merge nearby groups into telomere blocks.
 6. Filter blocks by minimum length and minimum repeat density.
-7. Label each surviving block as `p`, `q`, or `b` from strand composition.
+7. Label each surviving terminal block `p` or `q` from scan direction; label interstitial blocks `p`, `q`, or `b` from strand composition.
 8. Mark blocks as scaffold-terminal or contig-terminal from `-t/--terminal-limit`.
 9. Classify the sequence as `t2t`, `incomplete`, `misassembly`, `discordant`, or `none`.
 10. Write BED, TSV, and optional BEDgraph outputs.

--- a/docs/classification.md
+++ b/docs/classification.md
@@ -13,7 +13,7 @@ Teloscope classifies each sequence from scaffold-terminal telomere blocks only. 
 | `t2t` | `gapped_t2t` | one `p` block at the left end and one `q` block at the right end |
 | `incomplete` | `gapped_incomplete` | only one terminal arm is present |
 | `misassembly` | `gapped_misassembly` | terminal arms exist but the arrangement is wrong, or the same arm appears twice |
-| `discordant` | `gapped_discordant` | a terminal block is present but its strand composition contradicts its position |
+| `discordant` | `gapped_discordant` | a terminal block is present but it sits closer to the opposite end of the sequence than the end it was scanned from |
 | `none` | `gapped_none` | no scaffold-terminal telomere block was detected |
 
 The `gapped_` prefix is added when the sequence contains assembly gaps.
@@ -29,15 +29,22 @@ Teloscope applies the rules in this order:
 5. One arm present, plus a second scaffold-terminal block of the same arm: `misassembly`
 6. One terminal arm only: `incomplete`
 
+Rule 5 only fires when the opposite arm is absent. When both arms are present, rule 3 or 4 already returns a result first, so a duplicated arm next to a normal opposite arm is not flagged as `misassembly`.
+
 ## Block labels
 
-Each terminal block is labeled from strand balance:
+Terminal blocks are labeled from the end they were scanned from, not from strand balance:
+
+- `p`: found scanning from the start of the sequence
+- `q`: found scanning from the end of the sequence
+
+Interstitial blocks are labeled from strand balance instead:
 
 - `p`: forward-strand dominant
 - `q`: reverse-strand dominant
 - `b`: balanced or mixed
 
-The `granular` column in `*_report.tsv` shows the block pattern for each sequence.
+The `granular` column in `*_report.tsv` shows the block pattern for each sequence. It includes every terminal block along the sequence, not just the two at the scaffold ends, so a gapped scaffold with contig-internal terminal blocks can produce a longer string than the examples below.
 
 Examples:
 

--- a/docs/parameters.md
+++ b/docs/parameters.md
@@ -85,6 +85,8 @@ When `-s` equals `-w`, window outputs are non-overlapping BEDgraph bins.
 | `-y` | `--min-block-density` | minimum repeat-covered fraction for a block | `0.5` |
 | `-t` | `--terminal-limit` | distance from a sequence end that still counts as terminal | `50000` |
 
+A terminal sub-block also needs at least 2 matches before Teloscope keeps it. This minimum has no CLI flag.
+
 ## Output flags
 
 | Flag | Long form | Meaning | Default |
@@ -161,6 +163,8 @@ teloscope --bam-subset reads.bam -j 32 > telomeric.bam
 ```
 
 In read subset modes, the default `-l` is `42` bp. This is intended to retain reads with at least about seven telomeric repeat units after Teloscope's block and density filters. Assembly annotation keeps the stricter `300` bp default.
+
+Read subset modes also ignore `-t/--terminal-limit`: it is internally overridden so the whole read counts as terminal, regardless of the value passed on the command line.
 
 ## Stdin
 


### PR DESCRIPTION
Three docs pages describe behaviour that was replaced in March 2026 and never updated. `docs/outputs.md` already describes it correctly, so the docs currently contradict each other.

- `classification.md` said terminal blocks are labelled from strand balance. They are labelled from the end they were scanned from (`src/teloscope.cpp:193`). `computeBlockLabel` runs only for interstitial blocks (`:273`), so a terminal block is never `b`.
- `classification.md` said `discordant` means strand composition contradicts position. `hasValidOr` compares distances only (`:195-199`), never strand.
- `algorithm.md` step 7 applied strand labelling to every block. Only interstitial.
- Decision order now notes that rule 5 cannot fire when both arms are present, because rule 3 or 4 returns first (`:401-408` against `:411-427`).
- Granular label now notes it includes contig-internal blocks (`:349`), so gapped scaffolds give longer strings than the examples.
- `parameters.md` documents the undocumented 2-match minimum per terminal sub-block, and that `-t` is ignored in read subset modes (`src/read-filter.cpp:17`).

Docs only. No code change, no behaviour change.