### PR TITLE
Fix gzipped FASTQ and pipe input

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -92,10 +92,12 @@ int main(int argc, char **argv) {
     auto setInputFile = [&](const char* path) {
         ifFileExists(path);
         userInput.inSequence = path;
-        const std::filesystem::path real = std::filesystem::canonical(userInput.inSequence);
-        userInput.inSequence       = real.string();
-        userInput.inSequencePrefix = real.parent_path().string();
-        userInput.inSequenceName   = real.filename().string();
+        std::error_code pathError; // pipes and fd paths have no canonical form
+        const std::filesystem::path real = std::filesystem::canonical(userInput.inSequence, pathError);
+        const std::filesystem::path resolved = pathError ? std::filesystem::path(path) : real;
+        userInput.inSequence       = resolved.string();
+        userInput.inSequencePrefix = resolved.parent_path().string();
+        userInput.inSequenceName   = resolved.filename().string();
         if (!userInput.outRouteSet) // an explicit -o is not overridden by the input directory
             userInput.outRoute = userInput.inSequencePrefix;
     };


### PR DESCRIPTION
Two reported bugs in `--fastq-subset`, plus a coordinate bug found while tracing them. All three reproduced before and after.

**Gzipped FASTQ truncated at 1 MB.** `membuf` overrode `uflow()` but not `underflow()`. `std::getline` reads through `sgetc()`, which fell through to the base class and returned EOF the moment the 1 MB get area emptied. A 4.2 MB gzipped FASTQ died at record 20, exactly `1048576 / 52810`. It now scans all 80 records and produces output byte-identical to the plain file.

Gzipped FASTA was never affected: gfalibs defines its own `getline` that reads via `sbumpc()` and so drives the working `uflow()`. `loadGenome` calls it unqualified. `readFastqRecord` calls `std::getline`, and was the only vulnerable call site.

**Early close could hang.** The decompressor waited on a predicate that never tested `eof`, so `gzClose` could block forever. Both threads parked in futex wait. Added `eof` to the predicate with a matching break, and published `start` and `eof` under the mutex. The unlocked fast path in the new `underflow()` depends on that publication for its happens-before edge, so the two changes belong together.

**SIGABRT on any pipe or fd path.** `setInputFile` used the throwing `std::filesystem::canonical`, which threw on `/dev/fd/63` with nothing catching it. Now uses the `error_code` overload and keeps the path verbatim when it cannot be resolved, matching what `addBedFilterFile` already did twenty lines below.

**CRLF corrupted every coordinate.** gfalibs' `getline` skipped `\n` while accumulating but never `\r`, so each line left a stray byte in the sequence. A 3000 bp record reported 3050 and every coordinate shifted. At a wrap width that is not a multiple of the motif, matches were lost as well: canonical count fell from 200 to 188. Both now match the LF input exactly.

Deliberately not changed: `--fastq-subset` still uses `std::getline` and still round-trips CRLF in its output. That is existing tested behaviour, asserted by `fastq_subset_crlf.tst` and `test_bam_subset.py`. Switching it to the gfalibs overload broke both, which is how I caught it.

Verified: 182/182 goldens, bam subset, sequence filters and gaps suites all pass. Gzipped FASTA on the real chromosome is unchanged.