### PR TITLE
Add block regression comparison gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ testFiles/*_window_*.bedgraph
 /*_canonical_matches.bed
 /*_noncanonical_matches.bed
 /*_window_*.bedgraph
+
+# Block regression extractions
+/old_rows.tsv
+/new_rows.tsv

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ $(BUILD):
 $(BINDIR):
 	-mkdir -p $@
 
+.PHONY: test-block-regression
+test-block-regression:
+	bash scripts/test_block_regression.sh
+
 test-gaps: head
 	bash scripts/test_gaps_bed.sh
 

--- a/scripts/check_block_regression.py
+++ b/scripts/check_block_regression.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Extract per-scaffold block calls from a teloscope build, and compare two extractions.
+
+extract  runs the binary over the .tst fixtures and writes one sorted row per scaffold
+compare  joins two extractions, prints a scaffold-type transition matrix, and gates on a roster
+"""
+import argparse, os, re, shlex, subprocess, sys, tempfile
+
+FIELDS = ["fixture", "scaffold", "scaffold_type", "telomere_count",
+          "granular_label", "its_count", "terminal_blocks", "interstitial_blocks"]
+
+
+def granular_tokens(label):
+    """Split a granular label into one token per block: a letter plus an optional star."""
+    out, i = [], 0
+    while i < len(label):
+        tok = label[i]
+        i += 1
+        if i < len(label) and label[i] == "*":
+            tok += "*"
+            i += 1
+        out.append(tok)
+    return out
+
+
+def parse_report(path):
+    """Return (ultra_fast, [row dicts]). Columns are read by name, never by position."""
+    ultra, names, rows = None, None, []
+    with open(path) as fh:
+        for line in fh:
+            line = line.rstrip("\n")
+            if line.startswith("#params"):
+                m = re.search(r"ultra_fast=(\w+)", line)
+                if m:
+                    ultra = m.group(1) == "true"
+            elif line.startswith("#columns"):
+                names = line.split("\t")[1:]
+            elif not line or line.startswith("#") or line.startswith("+++"):
+                if line.startswith("+++"):
+                    break
+            elif names and line.split("\t")[0] == "pos":
+                continue
+            elif names:
+                parts = line.split("\t")
+                if len(parts) < len(names):
+                    continue
+                rows.append(dict(zip(names, parts)))
+    return ultra, rows
+
+
+def parse_blocks(path, has_tag):
+    """chrom -> list of (start, end, label, tag), sorted by start."""
+    out = {}
+    if not os.path.exists(path):
+        return out
+    with open(path) as fh:
+        for line in fh:
+            if line.startswith("#") or not line.strip():
+                continue
+            p = line.rstrip("\n").split("\t")
+            if len(p) < 4:
+                continue
+            tag = p[9] if has_tag and len(p) > 9 else "."
+            out.setdefault(p[0], []).append((int(p[1]), int(p[2]), p[3], tag))
+    for v in out.values():
+        v.sort()
+    return out
+
+
+def extract(binary, fixture_dir, out_path):
+    rows, skipped = [], 0
+    for name in sorted(os.listdir(fixture_dir)):
+        if not name.endswith(".tst"):
+            continue
+        with open(os.path.join(fixture_dir, name)) as fh:
+            cmd = fh.readline().strip()
+        if not cmd:
+            continue
+        with tempfile.TemporaryDirectory() as tmp:
+            cmd = cmd.replace("%OUTDIR%", tmp)
+            argv = shlex.split(cmd)
+            if "-o" not in argv and "--output" not in argv:
+                argv += ["-o", tmp]
+            if "-n" not in argv and "--manual-curation" not in argv:
+                argv += ["-n"]          # keeps BED rows aligned with the granular label
+            try:
+                subprocess.run([binary] + argv, cwd=os.getcwd(), timeout=300,
+                               stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            except subprocess.TimeoutExpired:
+                skipped += 1
+                continue
+            reports = [f for f in os.listdir(tmp) if f.endswith("_report.tsv")]
+            if not reports:
+                skipped += 1        # gfa, read-subset and error-exit fixtures
+                continue
+            base = reports[0][: -len("_report.tsv")]
+            ultra, rrows = parse_report(os.path.join(tmp, reports[0]))
+            term = parse_blocks(os.path.join(tmp, base + "_terminal_telomeres.bed"), True)
+            inter = parse_blocks(os.path.join(tmp, base + "_interstitial_telomeres.bed"), False)
+            for r in rrows:
+                chrom = r.get("header", "")
+                toks = granular_tokens(r.get("granular", ""))
+                tb = term.get(chrom, [])
+                tstr = ";".join(
+                    "%d-%d:%s:%s" % (s, e, toks[i] if i < len(toks) else lab, tag)
+                    for i, (s, e, lab, tag) in enumerate(tb)) or "-"
+                istr = ("NA" if ultra else
+                        ";".join("%d-%d:%s" % (s, e, lab)
+                                 for s, e, lab, _ in inter.get(chrom, [])) or "-")
+                rows.append([name, chrom, r.get("type", ""), r.get("telomeres", ""),
+                             r.get("granular", "") or "-",
+                             "NA" if ultra else r.get("its", ""), tstr, istr])
+    rows.sort(key=lambda r: (r[0], r[1]))
+    with open(out_path, "w") as fh:
+        fh.write("\t".join(FIELDS) + "\n")
+        for r in rows:
+            fh.write("\t".join(r) + "\n")
+    print("extracted %d scaffold rows, skipped %d fixtures with no report" % (len(rows), skipped))
+
+
+def load(path):
+    with open(path) as fh:
+        names = fh.readline().rstrip("\n").split("\t")
+        return {(r[0], r[1]): dict(zip(names, r))
+                for r in (l.rstrip("\n").split("\t") for l in fh) if len(r) == len(names)}
+
+
+def load_roster(path):
+    roster = {}
+    if not path or not os.path.exists(path):
+        return roster
+    with open(path) as fh:
+        for line in fh:
+            if line.startswith("#") or not line.strip():
+                continue
+            p = line.rstrip("\n").split("\t")
+            if len(p) >= 4:
+                roster[(p[0], p[1])] = (p[2], p[3])
+    return roster
+
+
+def compare(old_path, new_path, roster_path):
+    old, new, roster = load(old_path), load(new_path), load_roster(roster_path)
+    matrix, changed, failures = {}, [], []
+    for key in sorted(set(old) | set(new)):
+        o, n = old.get(key), new.get(key)
+        if o and n:
+            matrix.setdefault((o["scaffold_type"], n["scaffold_type"]), 0)
+            matrix[(o["scaffold_type"], n["scaffold_type"])] += 1
+        if o == n:
+            continue
+        if not o or not n:
+            failures.append((key, "removed" if not n else "added", "", ""))
+            continue
+        diff = [f for f in FIELDS[2:] if o[f] != n[f]]
+        changed.append((key, o["scaffold_type"], n["scaffold_type"], ",".join(diff)))
+        allowed = roster.get(key)
+        if not (allowed and allowed == (o["scaffold_type"], n["scaffold_type"])):
+            failures.append((key, o["scaffold_type"], n["scaffold_type"], ",".join(diff)))
+
+    print("\n=== scaffold type transitions ===")
+    off = 0
+    for (a, b), c in sorted(matrix.items()):
+        mark = "" if a == b else "   <-- off diagonal"
+        off += 0 if a == b else c
+        print("  %-22s -> %-22s %5d%s" % (a, b, c, mark))
+    print("  off-diagonal total: %d" % off)
+
+    if changed:
+        print("\n=== changed scaffolds ===")
+        for (fx, sc), a, b, d in changed:
+            print("  %s  %s  %s -> %s  [%s]" % (fx, sc, a, b, d))
+
+    if failures:
+        print("\n=== FAIL: %d change(s) not on the roster ===" % len(failures))
+        for (fx, sc), a, b, d in failures:
+            print("  %s\t%s\t%s\t%s\t<reason>\t<pr>" % (fx, sc, a, b))
+        print("\nAdd a roster line only with a real reason naming a plan section.")
+        return 1
+    print("\nPASS: no unrostered changes (%d scaffolds compared)" % len(set(old) & set(new)))
+    return 0
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    e = sub.add_parser("extract"); e.add_argument("--binary", required=True)
+    e.add_argument("--fixtures", default="validateFiles"); e.add_argument("--out", required=True)
+    c = sub.add_parser("compare"); c.add_argument("--old", required=True)
+    c.add_argument("--new", required=True); c.add_argument("--roster", default="")
+    a = ap.parse_args()
+    if a.cmd == "extract":
+        extract(a.binary, a.fixtures, a.out); return 0
+    return compare(a.old, a.new, a.roster)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_block_regression.sh
+++ b/scripts/test_block_regression.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Compare block calls between the current tree and a reference commit.
+# Builds the reference in a throwaway worktree so the current build is untouched.
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+cd "$ROOT"
+
+OLD_REF=${OLD_REF:-$(git merge-base origin/main HEAD 2>/dev/null || echo main)}
+ROSTER=${ROSTER:-validateFiles/repair_roster.tsv}
+WORK=$(mktemp -d "${TMPDIR:-/tmp}/teloscope_regress.XXXXXX")
+trap 'rm -rf "$WORK"; git worktree remove --force "$WORK/old" 2>/dev/null || true' EXIT
+
+echo "reference: $OLD_REF"
+
+echo "== building current =="
+make head -j"$(nproc 2>/dev/null || echo 4)" >/dev/null
+
+echo "== building reference in a worktree =="
+git worktree add -q --detach "$WORK/old" "$OLD_REF"
+git -C "$WORK/old" submodule update --init --recursive -q
+make -C "$WORK/old" head -j"$(nproc 2>/dev/null || echo 4)" >/dev/null
+
+echo "== extracting =="
+python3 scripts/check_block_regression.py extract \
+    --binary "$WORK/old/build/bin/teloscope" --out "$WORK/old_rows.tsv"
+python3 scripts/check_block_regression.py extract \
+    --binary "$ROOT/build/bin/teloscope" --out "$WORK/new_rows.tsv"
+
+cp "$WORK/old_rows.tsv" "$WORK/new_rows.tsv" "$ROOT/" 2>/dev/null || true
+
+echo "== comparing =="
+python3 scripts/check_block_regression.py compare \
+    --old "$WORK/old_rows.tsv" --new "$WORK/new_rows.tsv" --roster "$ROSTER"

--- a/validateFiles/repair_roster.tsv
+++ b/validateFiles/repair_roster.tsv
@@ -1,0 +1,3 @@
+# Scaffolds allowed to change, one line per fixture and scaffold.
+# A scaffold listed here still fails if it moves to a type other than the one pinned below.
+# fixture	scaffold	expected_old_type	expected_new_type	reason	pr


### PR DESCRIPTION
Tooling only. No behaviour change, no existing file touched except the Makefile and `.gitignore`.

The block-formation work will change classification output and regenerate roughly 146 machine-generated goldens. Reviewing that as a verbatim text diff is not review. This extracts structured per-scaffold rows from two builds and reports what actually moved.

`make test-block-regression` builds the merge base in a throwaway worktree, extracts from both binaries, and compares. Run it against the commit before the input hotfix, it reports 128 scaffolds and zero off-diagonal transitions, which is the correct answer since that fix was block-neutral.

Four details that are easy to get wrong and are handled:

- The run forces `-n`. The `i`-th terminal BED row lines up with the `i`-th granular label token because both iterate the same sorted vector, which is how the extraction recovers longest-block and orientation state that is not in any BED column. Without `-n` the BED omits contig-internal blocks and the correspondence breaks.
- `ultra_fast` is read from the provenance header and columns are mapped from the `#columns` line, since the report's column set varies by mode.
- Interstitial count is `NA` in ultra-fast mode, never `0`. Those blocks are not computed there, and a mode flip matters more than any number.
- Fixtures producing no report are skipped, which restricts this to the 128 report-producing fixtures without hardcoding a list and leaves GFA and read-subset tests to their existing checks.

The roster is keyed on fixture **and** scaffold and pins the exact type transition allowed. A scaffold on the roster that moves anywhere else still fails. The tool prints a stub on failure but never writes a reason, so a person has to.

It already surfaces real signal: `balanced.fa` reports overlapping `P` at 1200-2394 and `Q` at 1206-2400, one physical array counted as both arms.

Local target rather than a CI job, since it needs two builds, matching how `gfa-oracle` is handled.